### PR TITLE
[fix] only fetch version if build is happening

### DIFF
--- a/lib/middlewares/index.js
+++ b/lib/middlewares/index.js
@@ -5,6 +5,9 @@ var cookieParser = require('cookie-parser'),
     cors = require('access-control'),
     debugParam = require('./debug');
 
+var healthcheck = /healthcheck/;
+var rid = 0;
+
 module.exports = function (app, options, done) {
   //
   // Set some known middlewares on the app so that
@@ -24,6 +27,8 @@ module.exports = function (app, options, done) {
   app.use(cors(app.config.get('cors')));
 
   app.use(function httpLogger(req, res, next) {
+    // Reduce healthcheck logs as it creates unnecessary noise
+    if (healthcheck.test(req.url) && rid++ % 50 !== 0) return next();
     req.log.info('Start %s - %s', req.method, req.url, {
       method: req.method,
       url: req.url

--- a/lib/npm/routes.js
+++ b/lib/npm/routes.js
@@ -135,8 +135,8 @@ module.exports = function (app) {
   });
 
   /**
-   * Create a new tag for the specified package and data, also run a
-   * Carpenter build async.
+   * Create a new tag for the specified package and data, then either execute
+   * a rollback or a new build in carpenter
    *
    * @param {HTTPRequest} req Request from npm or similar client
    * @param {HTTPResponse} res Response to npm or similar client
@@ -149,7 +149,7 @@ module.exports = function (app) {
     var read = app.tagger.npm.urls.read;
     var pkg = req.params.pkg;
     var tag = req.params.tag;
-    app.tagger.add({ pkg, tag }, function distTagged(err, tags) {
+    app.tagger.add({ pkg, tag, version }, function distTagged(err, tags) {
       if (err) { return next(err); }
 
       /**
@@ -178,61 +178,93 @@ module.exports = function (app) {
         env: tag
       };
 
-      var buildSpec = Object.assign({ version }, spec);
-
-      function finish(err) {
+      rollbackOrBuild({ spec, version, log: req.log }, (err) => {
         if (err) return error(err);
 
-        req.log.info('Successful rollback to %s', version, buildSpec);
+
+        req.log.info('Successful rollback to %s', version, spec);
+      });
+    });
+  }
+
+  /**
+   *
+   * Either execute a rollback or a carpenter build
+   * @function rollbackOrBuild
+   * @param {Object} opts - options for function
+   * @param {Function} done - function to execute when complete
+   * @returns {undefined}
+   * @api private
+   */
+  function rollbackOrBuild(opts, done) {
+    var log = opts.log;
+    var spec = opts.spec;
+    var version = opts.version;
+    var buildSpec = Object.assign({ version }, spec);
+
+    //
+    // If this version already has a build associated, assume we want to
+    // rollback to that version
+    //
+    log.info('Searching for build based on tag', buildSpec);
+    app.bffs.search(buildSpec, function findPreviousBuild(err, build) {
+      if (build) {
+        log.info('Executing rollback, version %s found', version,  buildSpec);
+        return void app.bffs.rollback(spec, version, done);
       }
+      if (err) log.error(err);
+
       //
-      // If this version already has a build associated, assume we want to
-      // rollback to that version
+      // Only fetch version if this is not a rollback so we can rollback
+      // dependent builds that dont have explicit version records.
+      // TODO: We could make version records in feedsme but that would also
+      // mean we would have to replicate publish in feedsme
       //
-      req.log.info('Searching for build based on tag', buildSpec);
-      app.bffs.search(buildSpec, function findPreviousBuild(err, build) {
-        if (build) {
-          req.log.info('Executing rollback, version %s found', version,  buildSpec);
-          return app.bffs.rollback(spec, version, finish);
-        }
-        if (err) req.log.error(err);
-
+      carpenterBuild(opts, done);
+    });
+  }
+  /**
+   *
+   * Execute a carpenter build
+   * @function carpenterBuild
+   * @param {Object} opts - options for function
+   * @param {Function} done - function to execute when complete
+   * @returns {undefined}
+   * @api private
+   */
+  function carpenterBuild(opts, done) {
+    var spec = opts.spec;
+    var version = opts.version;
+    var log = opts.log;
+    var read = app.tagger.npm.urls.read;
+    Version.get(`${spec.name}@${version}`, function (err, vers) {
+      if (err) return done(err);
+      vers.forBuild(read, function (err, pack) {
+        if (err) return done(err);
         //
-        // Only fetch version if this is not a rollback so we can rollback
-        // dependent builds that dont have explicit version records.
-        // TODO: We could make version records in feedsme but that would also
-        // mean we would have to replicate publish in feedsme
+        // Don't wait for the build to complete as it can be longer
+        // that the default request timeout, before responding with the dist-tag
+        // details. In the case of any build errors remove the dist-tag.
+        // Add tag as environment to package and trigger build.
         //
-        Version.get(`${pkg}@${version}`, function (err, vers) {
-          if (err) return error(err);
-          vers.forBuild(function (err, pack) {
-            if (err) return error(err);
-            //
-            // Don't wait for the build to complete as it can be longer
-            // that the default request timeout, before responding with the dist-tag
-            // details. In the case of any build errors remove the dist-tag.
-            // Add tag as environment to package and trigger build.
-            //
-            pack.env = req.params.tag;
-            req.log.info('No previous build for %s, carpenter trigger', version, buildSpec);
-            app.carpenter.build({ data: pack }, function response(err, buildLog) {
-              if (err) { return error(err); }
+        pack.env = spec.env
+        log.info('No previous build for %s, carpenter trigger', version, spec);
+        app.carpenter.build({ data: pack }, function response(err, buildLog) {
+          if (err) { return done(err); }
 
-              //
-              // Log the streaming responses of the builder.
-              // TODO: can these be streamed back to npm?
-              //
-              buildLog.pipe(ndjson.parse())
-                .on('error', error)
-                .on('data', function onData(data) {
-                  if (data.event === 'error') {
-                    return error(err);
-                  }
+          //
+          // Log the streaming responses of the builder.
+          // TODO: can these be streamed back to npm?
+          //
+          buildLog.pipe(ndjson.parse())
+            .on('error', done)
+            .on('data', function onData(data) {
+              if (data.event === 'error') {
+                return done(data);
+              }
 
-                  req.log.info(data);
-                });
+              log.info(data);
             });
-          });
         });
       });
     });

--- a/lib/npm/routes.js
+++ b/lib/npm/routes.js
@@ -200,8 +200,8 @@ module.exports = function (app) {
         //
         // Only fetch version if this is not a rollback so we can rollback
         // dependent builds that dont have explicit version records.
-        // TODO: We could make version records in feedsme but that could be
-        // overkill
+        // TODO: We could make version records in feedsme but that would also
+        // mean we would have to replicate publish in feedsme
         //
         Version.get(`${pkg}@${version}`, function (err, vers) {
           if (err) return error(err);

--- a/lib/npm/routes.js
+++ b/lib/npm/routes.js
@@ -146,11 +146,10 @@ module.exports = function (app) {
    */
   function tagBuild(req, res, next) {
     var version = req.body;
-    app.tagger.add({
-      pkg: req.params.pkg,
-      tag: req.params.tag,
-      version
-    }, function distTagged(err, pack, tags) {
+    var read = app.tagger.npm.urls.read;
+    var pkg = req.params.pkg;
+    var tag = req.params.tag;
+    app.tagger.add({ pkg, tag }, function distTagged(err, tags) {
       if (err) { return next(err); }
 
       /**
@@ -174,17 +173,9 @@ module.exports = function (app) {
       //
       res.status(201).json(tags);
 
-      //
-      // Don't wait for the build to complete as it can be longer
-      // that the default request timeout, before responding with the dist-tag
-      // details. In the case of any build errors remove the dist-tag.
-      // Add tag as environment to package and trigger build.
-      //
-      pack.env = req.params.tag;
-
       var spec = {
-        name: req.params.pkg,
-        env: req.params.tag
+        name: pkg,
+        env: tag
       };
 
       var buildSpec = Object.assign({ version }, spec);
@@ -206,23 +197,42 @@ module.exports = function (app) {
         }
         if (err) req.log.error(err);
 
-        req.log.info('No previous build for %s, carpenter trigger', version, buildSpec);
-        app.carpenter.build({ data: pack }, function response(err, buildLog) {
-          if (err) { return error(err); }
+        //
+        // Only fetch version if this is not a rollback so we can rollback
+        // dependent builds that dont have explicit version records.
+        // TODO: We could make version records in feedsme but that could be
+        // overkill
+        //
+        Version.get(`${pkg}@${version}`, function (err, vers) {
+          if (err) return error(err);
+          vers.forBuild(function (err, pack) {
+            if (err) return error(err);
+            //
+            // Don't wait for the build to complete as it can be longer
+            // that the default request timeout, before responding with the dist-tag
+            // details. In the case of any build errors remove the dist-tag.
+            // Add tag as environment to package and trigger build.
+            //
+            pack.env = req.params.tag;
+            req.log.info('No previous build for %s, carpenter trigger', version, buildSpec);
+            app.carpenter.build({ data: pack }, function response(err, buildLog) {
+              if (err) { return error(err); }
 
-          //
-          // Log the streaming responses of the builder.
-          // TODO: can these be streamed back to npm?
-          //
-          buildLog.pipe(ndjson.parse())
-            .on('error', error)
-            .on('data', function onData(data) {
-              if (data.event === 'error') {
-                return error(err);
-              }
+              //
+              // Log the streaming responses of the builder.
+              // TODO: can these be streamed back to npm?
+              //
+              buildLog.pipe(ndjson.parse())
+                .on('error', error)
+                .on('data', function onData(data) {
+                  if (data.event === 'error') {
+                    return error(err);
+                  }
 
-              req.log.info(data);
+                  req.log.info(data);
+                });
             });
+          });
         });
       });
     });

--- a/lib/npm/tagger.js
+++ b/lib/npm/tagger.js
@@ -66,17 +66,8 @@ Tagger.prototype.delete = function (opts, callback) {
 Tagger.prototype.add = function (opts, callback) {
   var pkg = opts.pkg,
       tag = opts.tag,
-      version = opts.version,
-      Version = this.Version,
       Package = this.Package,
       read = this.npm.urls.read;
-
-  if (!version) {
-    return callback(errs.create({
-      message: util.format('Invalid version number: ', version),
-      status: 400
-    }));
-  }
 
   //
   // Create update body for cassandra
@@ -88,35 +79,9 @@ Tagger.prototype.add = function (opts, callback) {
 
   update.distTags[tag] = version;
 
-  async.parallel({
-    version: Version.get.bind(Version, [pkg, version].join('@')),
-    package: Package.update.bind(Package, update)
-  }, function (err, result) {
-    if (err) { return callback(err); }
-
-    if (!result.version) {
-      return callback(new Error('Package content cannot be retrieved'));
-    }
-
-    result.version.getAttachment(read, function gotAttachment(err, pack) {
-      if (err) { return callback(err); }
-
-      //
-      // The stored package of a particular version, including binary attachments.
-      //
-      var json = tryParse(pack.value);
-
-      if (!json) {
-        return callback(errs.create({
-          message: util.format('Unparseable value in Version document %s@%s', pkg, version),
-          value: pack.value,
-          status: 500
-        }));
-      }
-
-      json._attachments = pack._attachments;
-      callback(null, json, update.distTags);
-    });
+  Package.update(update, function (err) {
+    if (err) return callback(err);
+    callback(null, update.distTags);
   });
 };
 

--- a/lib/npm/tagger.js
+++ b/lib/npm/tagger.js
@@ -1,10 +1,5 @@
 'use strict';
 
-var async = require('async');
-var errs = require('errs');
-var util = require('util');
-var tryParse = require('json-try-parse');
-
 /**
  * @constructor Tagger
  *  @param {Object} opts - Options for configuring constructor
@@ -59,15 +54,14 @@ Tagger.prototype.delete = function (opts, callback) {
  * @function add
  *  @param {Object} opts - Options for add action
  *  @param {function} callback - continuation to call when finished
- * Updates / adds a specific dist-tag. This will kick off a build
- * from carpenter for the appropriate package(s).
+ * Updates / adds a specific dist-tag.
  * @returns {undefined}
  */
 Tagger.prototype.add = function (opts, callback) {
   var pkg = opts.pkg,
       tag = opts.tag,
-      Package = this.Package,
-      read = this.npm.urls.read;
+      version = opts.version,
+      Package = this.Package;
 
   //
   // Create update body for cassandra

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "slay-config": "^2.1.0",
     "slay-log": "^2.1.0",
     "stringify-stream": "^1.0.3",
-    "warehouse-models": "^5.1.1",
+    "warehouse-models": "~5.5.0",
     "winston": "^2.2.0",
     "zipline": "^1.0.0"
   },

--- a/test/integration/npm/routes.test.js
+++ b/test/integration/npm/routes.test.js
@@ -230,7 +230,6 @@ describe('npm routes', function () {
       it('serves 304 with the correct etag (GET /:pkg)', function (done) {
         helpers.etagFor('my-package-0.0.1', function (err, etag) {
           assume(err).is.falsey();
-          console.log(etag);
           request({
             uri: 'http://localhost:8092/my-package',
             headers: { 'if-none-match': etag },


### PR DESCRIPTION
Small refactor that requires https://github.com/warehouseai/warehouse-models/pull/1. Enables rollback for builds that dont have their explicit version stored in a registry or as a `Version` record. This helps for `dependent` build rollback.
