### PR TITLE
[fix] get rid of authorization header before we proxy

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -57,6 +57,8 @@ App.prototype.npmProxy = function (req, res, next) {
     this._npmTarget = attempt;
   }
 
+  if (req.headers.authorization) delete req.headers.authorization;
+
   req.log.info('Proxy to npm', {
     target: this._npmTarget,
     headers: req.headers,


### PR DESCRIPTION
this prevents us from setting the proper auth on the downstream endpoint