### PR TITLE
Expose list of build assets under `/assets/-/:pkg/:env/:version?`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 language: node_js
 node_js:
   - "8"
-  - "6"
 services:
   - cassandra
 before_install:

--- a/lib/preboots/index.js
+++ b/lib/preboots/index.js
@@ -22,6 +22,7 @@ module.exports = function (app, options, done) {
   app.preboot(require('./loading-bay'));
   app.preboot(require('./agents'));
   app.preboot(require('./carpenter'));
+  app.preboot(require('./spec'));
   app.preboot(require('./npm-auth'));
   app.preboot(require('../npm/preboot'));
 

--- a/lib/preboots/spec.js
+++ b/lib/preboots/spec.js
@@ -1,4 +1,14 @@
+const url = require('url');
 
+/**
+ *
+ * @param {slay.App} app - the global app instance
+ * @param {Object} opts - for extra configurability
+ * @param {function} done - continuation when preboot is finished
+ * @returns {undefined}
+ *
+ * Attaches the spec helpers to the `app` instance as `app.spec`.
+ */
 module.exports = function (app, opts, done) {
   //
   // TODO (indexzero): this should be configurable.
@@ -20,15 +30,15 @@ module.exports = function (app, opts, done) {
      * Generate a build specification from an inbound HTTP request
      * so we can fetch it from bffs.
      *
-     * @param {Object} req.params Parameters.
-     * @param {Object} req.query Query string args
+     * @param {IncomingRequest} req HTTP request to extract spec info from.
+     *   @param {Object} req.params Parameters.
+     *   @param {Object} req.query Query string args
      * @param {String} env Fallback environment in case it's missing.
      * @returns {Object} proper spec object
      * @api private
      */
     fromRequest: function spec(req, env) {
-      const { params, query } = req;
-      query = query || {};
+      const { params, query = {}} = req;
       return {
         env: params.env || env,
         version: params.version,
@@ -40,7 +50,7 @@ module.exports = function (app, opts, done) {
     /**
      * Responds with the build for the normalized `spec`
      * @param  {Object}   spec Description of the build
-     * @param  {Function} done Continuation to respond to when complete.
+     * @param  {Function} next Continuation to respond to when complete.
      */
     findBuild: function (spec, next) {
       var error;
@@ -90,13 +100,13 @@ module.exports = function (app, opts, done) {
         // Remark: Do a secondary lookup when we have a locale if we get a miss the first
         // time if we have a 2 part locale
         //
-        if (!build && !specs.locale) return notFound();
-        else if (!build && specs.locale) {
+        if (!build && !spec.locale) return notFound();
+        else if (!build && spec.locale) {
           //
           // 1. Try and grab the iso369 of the locale and refetch
           // 2. Otherwise try and fetch the defaultLocale
           // 3. Return notFound if all else fails
-          const lang = iso639(specs.locale);
+          const lang = iso639(spec.locale);
           if (lang) return refetch(lang);
           if (defaulted) return notFound();
           defaulted = true;
@@ -121,9 +131,9 @@ module.exports = function (app, opts, done) {
       // Ok so the assumption currently is that we will use the locale passed on
       // the query string or we use en-US for all of the builds fetched.
       //
-      return fetch(spec);
+      fetch(spec);
     }
-  }
+  };
 
   return done();
-}
+};

--- a/lib/preboots/spec.js
+++ b/lib/preboots/spec.js
@@ -1,0 +1,129 @@
+
+module.exports = function (app, opts, done) {
+  //
+  // TODO (indexzero): this should be configurable.
+  //
+  const defaultLocale = 'en-US';
+
+  //
+  // Returns back an iso639 string if given a full locale,
+  // if given the same iso639 string, returns null
+  //
+  function iso639(locale) {
+    const parts = locale.split('-');
+    if (parts[0] === locale) return null;
+    return parts[0];
+  }
+
+  app.spec = {
+    /**
+     * Generate a build specification from an inbound HTTP request
+     * so we can fetch it from bffs.
+     *
+     * @param {Object} req.params Parameters.
+     * @param {Object} req.query Query string args
+     * @param {String} env Fallback environment in case it's missing.
+     * @returns {Object} proper spec object
+     * @api private
+     */
+    fromRequest: function spec(req, env) {
+      const { params, query } = req;
+      query = query || {};
+      return {
+        env: params.env || env,
+        version: params.version,
+        name: params.pkg,
+        locale: query.locale || defaultLocale
+      };
+    },
+
+    /**
+     * Responds with the build for the normalized `spec`
+     * @param  {Object}   spec Description of the build
+     * @param  {Function} done Continuation to respond to when complete.
+     */
+    findBuild: function (spec, next) {
+      var error;
+      var defaulted = false;
+
+      //
+      // Normalzie the build object
+      //
+      function normalizeBuild(build) {
+        function normalizeUrl(filePath) {
+          return url.resolve(build.cdnUrl, filePath);
+        }
+
+        build.files = build.recommended.length
+          ? build.recommended.map(normalizeUrl)
+          : build.artifacts.map(normalizeUrl);
+
+        return build;
+      }
+
+      //
+      // Responds with a 404 not found error.
+      //
+      function notFound() {
+        error = new Error('Build not found');
+        error.status = 404;
+        return next(error);
+      }
+
+      function fetch(spec) {
+        //
+        // If we have a version, do search, otherwise fetch from HEAD,
+        // we may want to automatically handle this in `bffs`
+        //
+        return spec.version
+          ? app.bffs.search(spec, fetched)
+          : app.bffs.head(spec, fetched);
+      }
+
+      function fetched(err, build) {
+        if (err) {
+          err.status = 500;
+          return next(err);
+        }
+
+        //
+        // Remark: Do a secondary lookup when we have a locale if we get a miss the first
+        // time if we have a 2 part locale
+        //
+        if (!build && !specs.locale) return notFound();
+        else if (!build && specs.locale) {
+          //
+          // 1. Try and grab the iso369 of the locale and refetch
+          // 2. Otherwise try and fetch the defaultLocale
+          // 3. Return notFound if all else fails
+          const lang = iso639(specs.locale);
+          if (lang) return refetch(lang);
+          if (defaulted) return notFound();
+          defaulted = true;
+          return refetch(defaultLocale);
+        }
+
+        //
+        // Grab the relevant file info for the fingerprints on these builds
+        //
+        next(null, normalizeBuild(build.toJSON()));
+      }
+
+      //
+      // Retries fetch for build with given locale string
+      //
+      function refetch(locale) {
+        spec.locale = locale;
+        return fetch(spec);
+      }
+
+      //
+      // Ok so the assumption currently is that we will use the locale passed on
+      // the query string or we use en-US for all of the builds fetched.
+      //
+      return fetch(spec);
+    }
+  }
+
+  return done();
+}

--- a/lib/routes/assets.js
+++ b/lib/routes/assets.js
@@ -1,11 +1,11 @@
 /* eslint no-bitwise: 0*/
 'use strict';
 
-var comment = require('commenting'),
-  zipline = require('zipline'),
-  hyperquest = require('hyperquest'),
-  mime = require('mime'),
-  path = require('path');
+const comment = require('commenting');
+const zipline = require('zipline');
+const hyperquest = require('hyperquest');
+const mime = require('mime');
+const path = require('path');
 
 //
 // As our intention is to primary serve JS builds, this should be our default
@@ -14,6 +14,38 @@ var comment = require('commenting'),
 mime.default_type = 'text/javascript';
 
 module.exports = function (app) {
+  const spec = app.spec;
+
+  /*
+   * API for serving latest files
+   */
+  app.routes.get('/assets/-/:pkg/:env/:version?', function (req, res) {
+    res.setHeader('Content-Type', 'application/json');
+    res.statusCode = 200;
+
+    spec.findBuild(
+      spec.fromRequest(req),
+      function (err, build) {
+        if (err) { return next(err); }
+
+        //
+        // TODO (indexzero): proper sanitization on this untrusted
+        // user input.
+        //
+        const { filter } = req.query;
+        if (filter) {
+          res.send(
+            build.files.filter(file => {
+              return path.extname(file) === filter;
+            });
+          )
+        }
+
+        res.send(build.files);
+      }
+    );
+  });
+
   /**
    * API endpoint for serving builds.
    * TODO: Whats the right way to support gzip if our content is stored in an

--- a/lib/routes/assets.js
+++ b/lib/routes/assets.js
@@ -19,7 +19,7 @@ module.exports = function (app) {
   /*
    * API for serving latest files
    */
-  app.routes.get('/assets/-/:pkg/:env/:version?', function (req, res) {
+  app.routes.get('/assets/-/:pkg/:env/:version?', function (req, res, next) {
     res.setHeader('Content-Type', 'application/json');
     res.statusCode = 200;
 
@@ -37,8 +37,8 @@ module.exports = function (app) {
           res.send(
             build.files.filter(file => {
               return path.extname(file) === filter;
-            });
-          )
+            })
+          );
         }
 
         res.send(build.files);

--- a/lib/routes/assets.js
+++ b/lib/routes/assets.js
@@ -28,10 +28,6 @@ module.exports = function (app) {
       function (err, build) {
         if (err) { return next(err); }
 
-        //
-        // TODO (indexzero): proper sanitization on this untrusted
-        // user input.
-        //
         let { filter } = req.query;
         if (filter.length > 50) {
           res.statusCode = 400;

--- a/lib/routes/assets.js
+++ b/lib/routes/assets.js
@@ -19,7 +19,7 @@ module.exports = function (app) {
   /*
    * API for serving latest files
    */
-  app.routes.get('/assets/-/:pkg/:env/:version?', function (req, res, next) {
+  app.routes.get('/assets/files/:pkg/:env/:version?', function (req, res, next) {
     res.setHeader('Content-Type', 'application/json');
     res.statusCode = 200;
 
@@ -32,16 +32,21 @@ module.exports = function (app) {
         // TODO (indexzero): proper sanitization on this untrusted
         // user input.
         //
-        const { filter } = req.query;
-        if (filter) {
-          res.send(
-            build.files.filter(file => {
-              return path.extname(file) === filter;
-            })
-          );
+        let { filter } = req.query;
+        if (filter.length > 50) {
+          res.statusCode = 400;
+          return res.json({ error: `${req.query} is too many characters. Limit 50.` });
         }
 
-        res.send(build.files);
+        if (filter) {
+          res.send({
+            files: build.files.filter(file => {
+              return file.includes(filter);
+            })
+          });
+        }
+
+        res.send({ files: build.files });
       }
     );
   });

--- a/lib/routes/assets.js
+++ b/lib/routes/assets.js
@@ -20,7 +20,6 @@ module.exports = function (app) {
    * API for serving latest files
    */
   app.routes.get('/assets/files/:pkg/:env/:version?', function (req, res, next) {
-    res.setHeader('Content-Type', 'application/json');
     res.statusCode = 200;
 
     spec.findBuild(
@@ -28,22 +27,21 @@ module.exports = function (app) {
       function (err, build) {
         if (err) { return next(err); }
 
-        let { filter } = req.query;
-        if (filter.length > 50) {
-          res.statusCode = 400;
-          return res.json({ error: `${req.query} is too many characters. Limit 50.` });
-        }
-
+        const filter = req.query.filter;
         if (filter) {
-          filter = filter.toLowercase();
-          res.send({
+          if (filter.length > 50) {
+            res.statusCode = 400;
+            return res.json({ error: `${filter} is too many characters. Limit 50.` });
+          }
+
+          res.json({
             files: build.files.filter(file => {
-              return file.toLowercase().includes(filter);
+              return file.toString().toLowerCase().includes(filter.toLowerCase());
             })
           });
+        } else {
+          res.json({ files: build.files });
         }
-
-        res.send({ files: build.files });
       }
     );
   });
@@ -62,7 +60,10 @@ module.exports = function (app) {
         ? req.params.hash.slice(0, -(extension.length))
         : req.params.hash;
 
-    res.setHeader('Content-Type', mime.lookup(req.params.hash));
+    res.set('Content-Type', mime.lookup(req.params.hash));
+    if (gzip) {
+      res.set('content-encoding', 'gzip');
+    }
     res.statusCode = 200;
 
     res.log.debug('bffs using gzip: ' + gzip);

--- a/lib/routes/assets.js
+++ b/lib/routes/assets.js
@@ -39,9 +39,10 @@ module.exports = function (app) {
         }
 
         if (filter) {
+          filter = filter.toLowercase();
           res.send({
             files: build.files.filter(file => {
-              return file.includes(filter);
+              return file.toLowercase().includes(filter);
             })
           });
         }

--- a/lib/routes/builds.js
+++ b/lib/routes/builds.js
@@ -27,7 +27,7 @@ module.exports = function (app) {
   app.routes.get('/builds/-/meta/:pkg/:version', auth, function (req, res, next) {
     var error;
 
-    app.bffs.meta(spec(req.params, req.query), function meta(err, build) {
+    app.bffs.meta(spec.fromRequest(req), function meta(err, build) {
       if (err) {
         return next(err);
       }

--- a/lib/routes/builds.js
+++ b/lib/routes/builds.js
@@ -109,6 +109,6 @@ module.exports = function (app) {
         if (err) { return next(err); }
         res.send(build);
       }
-    )
+    );
   });
 };

--- a/lib/routes/builds.js
+++ b/lib/routes/builds.js
@@ -24,6 +24,24 @@ module.exports = function (app) {
 
   });
 
+  app.routes.get('/builds/-/meta/:pkg/:version', auth, function (req, res, next) {
+    var error;
+
+    app.bffs.meta(spec(req.params, req.query), function meta(err, build) {
+      if (err) {
+        return next(err);
+      }
+
+      if (!build) {
+        error = new Error('Build not found');
+        error.status = 404;
+        return next(error);
+      }
+
+      res.send(build);
+    });
+  });
+
   //
   // ### /builds/
   // List ALL of the builds that are in the database
@@ -75,24 +93,6 @@ module.exports = function (app) {
         response.pipe(res);
       }).on('error', next);
     });
-
-  app.routes.get('/builds/-/meta/:pkg/:version', auth, function (req, res, next) {
-    var error;
-
-    app.bffs.meta(spec(req.params, req.query), function meta(err, build) {
-      if (err) {
-        return next(err);
-      }
-
-      if (!build) {
-        error = new Error('Build not found');
-        error.status = 404;
-        return next(error);
-      }
-
-      res.send(build);
-    });
-  });
 
   //
   // ### /builds/:pkg/:version/:env

--- a/lib/routes/builds.js
+++ b/lib/routes/builds.js
@@ -5,28 +5,9 @@ var url = require('url');
 var stringify = require('stringify-stream');
 
 const stringifyOpts = { open: '[', close: ']' };
-const defaultLocale = 'en-US';
-
-/**
- * Generate a build specification so we can fetch it from bffs.
- *
- * @param {Object} params Parameters.
- * @param {Object} query Query string args
- * @param {String} env Fallback environment in case it's missing.
- * @returns {Object} proper spec object
- * @api private
- */
-function spec(params, query, env) {
-  query = query || {};
-  return {
-    env: params.env || env,
-    version: params.version,
-    name: params.pkg,
-    locale: query.locale || defaultLocale
-  };
-}
 
 module.exports = function (app) {
+  const spec = app.spec;
   const auth = app.middlewares.auth;
   //
   // ### /builds/head
@@ -119,97 +100,15 @@ module.exports = function (app) {
   // environments if no env is specified.
   //
   app.routes.get('/builds/:pkg/:env/:version?', auth, function (req, res, next) {
-    var error;
-    var defaulted = false;
-
     res.setHeader('Content-Type', 'application/json');
     res.statusCode = 200;
 
-    //
-    // Normalzie the build object
-    //
-    function normalizeBuild(build) {
-
-      function normalizeUrl(filePath) {
-        return url.resolve(build.cdnUrl, filePath);
+    spec.findBuild(
+      spec.fromRequest(req),
+      function (err, build) {
+        if (err) { return next(err); }
+        res.send(build);
       }
-
-      build.files = build.recommended.length
-        ? build.recommended.map(normalizeUrl)
-        : build.artifacts.map(normalizeUrl);
-
-      return build;
-    }
-
-    //
-    // Ok so the assumption currently is that we will use the locale passed on
-    // the query string or we use en-US for all of the builds fetched.
-    //
-    var specs = spec(req.params, req.query);
-
-    return fetch(specs);
-
-    function notFound() {
-      error = new Error('Build not found');
-      error.status = 404;
-      return next(error);
-    }
-
-    function fetch(spec) {
-      //
-      // If we have a version, do search, otherwise fetch from HEAD,
-      // we may want to automatically handle this in `bffs`
-      //
-      return spec.version
-        ? app.bffs.search(spec, fetched)
-        : app.bffs.head(spec, fetched);
-    }
-
-    function fetched(err, build) {
-      if (err) {
-        err.status = 500;
-        return next(err);
-      }
-
-      //
-      // Remark: Do a secondary lookup when we have a locale if we get a miss the first
-      // time if we have a 2 part locale
-      //
-      if (!build && !specs.locale) return notFound();
-      else if (!build && specs.locale) {
-        //
-        // 1. Try and grab the iso369 of the locale and refetch
-        // 2. Otherwise try and fetch the defaultLocale
-        // 3. Return notFound if all else fails
-        const lang = iso639(specs.locale);
-        if (lang) return refetch(lang);
-        if (defaulted) return notFound();
-        defaulted = true;
-        return refetch(defaultLocale);
-      }
-
-      //
-      // Grab the relevant file info for the fingerprints on these builds
-      //
-      res.send(normalizeBuild(build.toJSON()));
-    }
-
-    //
-    // Retries fetch for build with given locale string
-    //
-    function refetch(locale) {
-      specs.locale = locale;
-      return fetch(specs);
-    }
+    )
   });
 };
-
-//
-// Returns back an iso639 string if given a full locale,
-// if given the same iso639 string, returns null
-//
-function iso639(locale) {
-  const parts = locale.split('-');
-  if (parts[0] === locale) return null;
-  return parts[0];
-}

--- a/test/fixtures/payloads/my-styles.css
+++ b/test/fixtures/payloads/my-styles.css
@@ -1,0 +1,3 @@
+body{ 
+  color: chartreuse;
+}

--- a/test/integration/routes/assets.test.js
+++ b/test/integration/routes/assets.test.js
@@ -38,7 +38,7 @@ describe('/assets/*', function () {
       }, {
         content: cssContent,
         compressed: cssGzip,
-        fingerprint: '3x4mp311d',
+        fingerprint: '3x4mp311e',
         filename: 'my-styles.css',
         extension: '.css'
       }]
@@ -146,7 +146,7 @@ describe('/assets/*', function () {
     });
   });
 
-  describe.skip('/assets/:hash', function () {
+  describe('/assets/:hash', function () {
     it('serves a safe 404 for css files', function (next) {
       request(address(app, {
         pathname: 'assets/ishouldexist.css'

--- a/test/integration/routes/assets.test.js
+++ b/test/integration/routes/assets.test.js
@@ -22,7 +22,7 @@ function address(app, properties) {
 // TODO: Need testing config for publishing to s3 to store encrypted with
 // travis
 //
-describe('/assets/*', function () {
+describe.skip('/assets/*', function () {
   var jsContent = path.join(__dirname, 'builds.test.js'),
     jsGzip = path.join(require('os').tmpdir(), 'build.test.js'),
     cssContent = path.join(__dirname, '..', '..', 'fixtures', 'payloads', 'my-styles.css'),

--- a/test/integration/routes/assets.test.js
+++ b/test/integration/routes/assets.test.js
@@ -63,59 +63,69 @@ describe.skip('/assets/*', function () {
     assume(app.bffs).is.a('object');
   });
 
-  it('serves a safe 404 for css files', function (next) {
-    request(address(app, {
-      pathname: 'assets/ishouldexist.css'
-    }), function (err, res, body) {
-      assume(err).doesnt.exist();
-      assume(res.statusCode).equals(404);
-      assume(res.headers['content-type']).equals('text/css; charset=utf-8');
-      assume(body.toString()).includes('* Build not found');
-
-      next();
-    });
+  describe('/assets/files/*', function () {
+    it('serves files for a given build');
+    it('responds with a 404 when appropriate');
+    it('accepts a filter to match filenames');
+    it('ignores case in filter parameters');
+    it('responds with 400 when filter is greater than 50 chars');
   });
 
-  it('serves a safe 404 for js files', function (next) {
-    request(address(app, {
-      pathname: 'assets/ishouldexist.js'
-    }), function (err, res, body) {
-      assume(err).doesnt.exist();
-      assume(res.statusCode).equals(404);
-      assume(res.headers['content-type']).equals('application/javascript; charset=utf-8');
-      assume(body.toString()).includes('* Build not found');
+  describe('/assets/:hash', function () {
+    it('serves a safe 404 for css files', function (next) {
+      request(address(app, {
+        pathname: 'assets/ishouldexist.css'
+      }), function (err, res, body) {
+        assume(err).doesnt.exist();
+        assume(res.statusCode).equals(404);
+        assume(res.headers['content-type']).equals('text/css; charset=utf-8');
+        assume(body.toString()).includes('* Build not found');
 
-      next();
+        next();
+      });
     });
-  });
 
-  it('serves the specified build', function (next) {
-    request(address(app, {
-      pathname: 'assets/3x4mp311d.js'
-    }), function (err, res, body) {
-      assume(err).doesnt.exist();
-      assume(res.statusCode).equals(200);
-      assume(res.headers['content-type']).includes('application/javascript');
-      assume(body).deep.equals(fs.readFileSync(content, 'utf8'));
+    it('serves a safe 404 for js files', function (next) {
+      request(address(app, {
+        pathname: 'assets/ishouldexist.js'
+      }), function (err, res, body) {
+        assume(err).doesnt.exist();
+        assume(res.statusCode).equals(404);
+        assume(res.headers['content-type']).equals('application/javascript; charset=utf-8');
+        assume(body.toString()).includes('* Build not found');
 
-      next();
+        next();
+      });
     });
-  });
 
-  it.skip('serves gzip responses', function (next) {
-    request({
-      url: address(app, { pathname: 'assets/3x4mp311d.js' }),
-      headers: {
-        'Accept-Encoding': 'gzip'
-      }
-    }, function (err, res, body) {
-      assume(err).doesnt.exist();
-      assume(res.statusCode).equals(200);
-      assume(res.headers['content-type']).includes('application/javascript');
-      assume(res.headers['content-encoding']).equals('gzip');
-      assume(body).deep.equals(fs.readFileSync(gzip, 'utf8'));
+    it('serves the specified build', function (next) {
+      request(address(app, {
+        pathname: 'assets/3x4mp311d.js'
+      }), function (err, res, body) {
+        assume(err).doesnt.exist();
+        assume(res.statusCode).equals(200);
+        assume(res.headers['content-type']).includes('application/javascript');
+        assume(body).deep.equals(fs.readFileSync(content, 'utf8'));
 
-      next();
+        next();
+      });
+    });
+
+    it.skip('serves gzip responses', function (next) {
+      request({
+        url: address(app, { pathname: 'assets/3x4mp311d.js' }),
+        headers: {
+          'Accept-Encoding': 'gzip'
+        }
+      }, function (err, res, body) {
+        assume(err).doesnt.exist();
+        assume(res.statusCode).equals(200);
+        assume(res.headers['content-type']).includes('application/javascript');
+        assume(res.headers['content-encoding']).equals('gzip');
+        assume(body).deep.equals(fs.readFileSync(gzip, 'utf8'));
+
+        next();
+      });
     });
   });
 });

--- a/test/integration/routes/assets.test.js
+++ b/test/integration/routes/assets.test.js
@@ -22,22 +22,31 @@ function address(app, properties) {
 // TODO: Need testing config for publishing to s3 to store encrypted with
 // travis
 //
-describe.skip('/assets/*', function () {
-  var content = path.join(__dirname, 'builds.test.js'),
-    gzip = path.join(require('os').tmpdir(), 'build.test.js'),
+describe('/assets/*', function () {
+  var jsContent = path.join(__dirname, 'builds.test.js'),
+    jsGzip = path.join(require('os').tmpdir(), 'build.test.js'),
+    cssContent = path.join(__dirname, '..', '..', 'fixtures', 'payloads', 'my-styles.css'),
+    cssGzip = path.join(require('os').tmpdir(), 'my-styles.css'),
     spec = { name: 'pancake', version: '0.0.1', env: 'test' },
     publishOptions = {
       files: [{
-        content: content,
-        compressed: gzip,
+        content: jsContent,
+        compressed: jsGzip,
         fingerprint: '3x4mp311d',
         filename: 'builds.test.js',
         extension: '.js'
+      }, {
+        content: cssContent,
+        compressed: cssGzip,
+        fingerprint: '3x4mp311d',
+        filename: 'my-styles.css',
+        extension: '.css'
       }]
     },
     app;
 
-  fs.writeFileSync(gzip, zlib.gzipSync(fs.readFileSync(content)));
+  fs.writeFileSync(jsGzip, zlib.gzipSync(fs.readFileSync(jsContent)));
+  fs.writeFileSync(cssGzip, zlib.gzipSync(fs.readFileSync(cssContent)));
 
   before(function (next) {
     helpers.start({ http: 0 }, function (err, ret) {
@@ -64,14 +73,80 @@ describe.skip('/assets/*', function () {
   });
 
   describe('/assets/files/*', function () {
-    it('serves files for a given build');
-    it('responds with a 404 when appropriate');
-    it('accepts a filter to match filenames');
-    it('ignores case in filter parameters');
-    it('responds with 400 when filter is greater than 50 chars');
+    it('serves files for a given build', function (next) {
+      request(address(app, {
+        pathname: 'assets/files/pancake/test/0.0.1'
+      }), function (err, res, body) {
+        assume(err).doesnt.exist();
+        assume(res.statusCode).equals(200);
+        assume(res.headers['content-type']).equals('application/json; charset=utf-8');
+        const jsonBody = JSON.parse(body);
+        assume(jsonBody.files).exist();
+        assume(jsonBody.files).has.length(2);
+        assume(body.toString()).includes('/builds.test.js');
+
+        next();
+      });
+    });
+    it('responds with a 404 when appropriate', function (next) {
+      request(address(app, {
+        pathname: 'assets/files/pancake/test/0.0.2'
+      }), function (err, res) {
+        assume(err).doesnt.exist();
+        assume(res.statusCode).equals(404);
+
+        next();
+      });
+    });
+    it('accepts a filter to match filenames', function (next) {
+      request(address(app, {
+        pathname: 'assets/files/pancake/test/0.0.1',
+        query: { filter: 'css' }
+      }), function (err, res, body) {
+        assume(err).doesnt.exist();
+        assume(res.statusCode).equals(200);
+        assume(res.headers['content-type']).equals('application/json; charset=utf-8');
+        const jsonBody = JSON.parse(body);
+        assume(jsonBody.files).exist();
+        assume(jsonBody.files).has.length(1);
+        assume(body.toString()).includes('/my-styles.css');
+        assume(body.toString()).doesnt.includes('/builds.test.js');
+
+        next();
+      });
+    });
+    it('ignores case in filter parameters', function (next) {
+      request(address(app, {
+        pathname: 'assets/files/pancake/test/0.0.1',
+        query: { filter: 'CSS' }
+      }), function (err, res, body) {
+        assume(err).doesnt.exist();
+        assume(res.statusCode).equals(200);
+        assume(res.headers['content-type']).equals('application/json; charset=utf-8');
+        const jsonBody = JSON.parse(body);
+        assume(jsonBody.files).exist();
+        assume(jsonBody.files).has.length(1);
+        assume(body.toString()).includes('/my-styles.css');
+        assume(body.toString()).doesnt.includes('/builds.test.js');
+
+        next();
+      });
+    });
+    it('responds with 400 when filter is greater than 50 chars', function (next) {
+      request(address(app, {
+        pathname: 'assets/files/pancake/test/0.0.1',
+        query: { filter: 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz' }
+      }), function (err, res) {
+        assume(err).doesnt.exist();
+        assume(res.statusCode).equals(400);
+        assume(res.headers['content-type']).equals('application/json; charset=utf-8');
+
+        next();
+      });
+    });
   });
 
-  describe('/assets/:hash', function () {
+  describe.skip('/assets/:hash', function () {
     it('serves a safe 404 for css files', function (next) {
       request(address(app, {
         pathname: 'assets/ishouldexist.css'
@@ -105,7 +180,7 @@ describe.skip('/assets/*', function () {
         assume(err).doesnt.exist();
         assume(res.statusCode).equals(200);
         assume(res.headers['content-type']).includes('application/javascript');
-        assume(body).deep.equals(fs.readFileSync(content, 'utf8'));
+        assume(body).deep.equals(fs.readFileSync(jsContent, 'utf8'));
 
         next();
       });
@@ -122,7 +197,7 @@ describe.skip('/assets/*', function () {
         assume(res.statusCode).equals(200);
         assume(res.headers['content-type']).includes('application/javascript');
         assume(res.headers['content-encoding']).equals('gzip');
-        assume(body).deep.equals(fs.readFileSync(gzip, 'utf8'));
+        assume(body).deep.equals(fs.readFileSync(jsGzip, 'utf8'));
 
         next();
       });


### PR DESCRIPTION
Follow-up from our discussion today @jcrugzz:

1. `GET /assets/-/:pkg/:env/:version?` is unauthenticated. This is safe because the `files` within any `Build` is public by definition. 
2. Deduplicates code from `GET /builds/:pkg/:env/:version?` into `app.spec.{fromRequest,findBuild}` which is used in both locations. This route should exist and should remain authenticated since the other build metadata is **not** public by definition.

#### Before merging:

- [x] Integration tests
- [x] Define filtering semantics
- [x] Discuss if an _"I'm feeling lucky"_ style route is useful with a particular HTTP encoding (i.e. returning the first file in the set of files as text).