### PR TITLE
Regenerate package-lock.json with correct registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "@sinonjs/commons": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@sinonjs/commons/-/commons-1.0.2.tgz",
-      "integrity": "sha1-PgrHN3gWJ7iEQlf63D2AOZfQUm4=",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
+      "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -15,52 +15,66 @@
       "dependencies": {
         "type-detect": {
           "version": "4.0.8",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/type-detect/-/type-detect-4.0.8.tgz",
-          "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
           "dev": true
         }
       }
     },
     "@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha1-hNt+nrVTHfGKjF4L+25EnlXmVLI=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
+      "integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "@sinonjs/samsam": "2.1.0"
+      },
+      "dependencies": {
+        "@sinonjs/samsam": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
+          "integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+          "dev": true,
+          "requires": {
+            "array-from": "^2.1.1"
+          }
+        }
       }
     },
     "@sinonjs/samsam": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@sinonjs/samsam/-/samsam-2.0.0.tgz",
-      "integrity": "sha1-kWN0KsNcEtNgLeznQxdkOzXbaoA=",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.1.tgz",
+      "integrity": "sha512-7oX6PXMulvdN37h88dvlvRyu61GYZau40fL4wEZvPEHvrjpJc3lDv6xDM5n4Z0StufUVB5nDvVZUM+jZHdMOOQ==",
+      "dev": true,
+      "requires": {
+        "array-from": "^2.1.1"
+      }
     },
     "@types/caseless": {
       "version": "0.12.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@types/caseless/-/caseless-0.12.1.tgz",
-      "integrity": "sha1-l5TGnIOF0BkqzEcaVA0fjg0WIYo=",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A==",
       "dev": true
     },
     "@types/form-data": {
       "version": "2.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@types/form-data/-/form-data-2.2.1.tgz",
-      "integrity": "sha1-7is7jqoRwJOCiZU2BrdFtzjFSx4=",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "10.9.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@types/node/-/node-10.9.2.tgz",
-      "integrity": "sha1-8KuNztXNbFayZ2XhwNnk/cyfKgA=",
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.3.tgz",
+      "integrity": "sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ==",
       "dev": true
     },
     "@types/request": {
       "version": "2.47.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@types/request/-/request-2.47.1.tgz",
-      "integrity": "sha1-JUENOvvawEyRqUrZ78mCQQBzWCQ=",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
+      "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
       "dev": true,
       "requires": {
         "@types/caseless": "*",
@@ -71,8 +85,8 @@
     },
     "@types/tough-cookie": {
       "version": "2.3.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-fyJtZ9ZU7JBw51X0ba6/AUYo6dk=",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ==",
       "dev": true
     },
     "@wrhs/release-line": {
@@ -81,55 +95,12 @@
       "integrity": "sha512-0TD4BwGj7+0MjsCTd5A5jJPXX5vRL5ZuMXkZ/NePqXJjWIyinW8nnYNjN65FxtyvtQJwiEMniJMFpYIhA9luKQ==",
       "requires": {
         "datastar": "^1.6.0"
-      },
-      "dependencies": {
-        "datastar": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/datastar/-/datastar-1.6.0.tgz",
-          "integrity": "sha512-0oeBxYftzzh37XKy+JXj1Ivs9zMswNiKGFu8rp84K06jmbDkTLYIp5+Anpdn/75Ht4BJIPa2qdSKphdALyk/8Q==",
-          "requires": {
-            "async": "^1.5.0",
-            "clone": "^1.0.4",
-            "joi-of-cql": "^1.0.2",
-            "list-stream": "^1.0.0",
-            "lodash.pick": "^4.0.1",
-            "object-assign": "^4.0.1",
-            "one-time": "0.0.4",
-            "priam": "^2.1.0",
-            "read-only-stream": "^2.0.0",
-            "through2": "^2.0.0",
-            "tinythen": "^1.0.1",
-            "to-camel-case": "^1.0.0",
-            "to-snake-case": "^1.0.0",
-            "understudy": "^4.1.0",
-            "uuid": "^2.0.1"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
-          }
-        },
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-        }
       }
     },
     "JSONStream": {
       "version": "1.3.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/JSONStream/-/JSONStream-1.3.4.tgz",
-      "integrity": "sha1-YVuyrbDNNMj0xEe19lEvodjxai4=",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.4.tgz",
+      "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
       "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -137,7 +108,7 @@
     },
     "accepts": {
       "version": "1.3.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/accepts/-/accepts-1.3.5.tgz?dl=https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
         "mime-types": "~2.1.18",
@@ -146,8 +117,8 @@
     },
     "access-control": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/access-control/-/access-control-1.0.1.tgz",
-      "integrity": "sha1-/AjO7RHOohV2xQ7fw98JucJAVS4=",
+      "resolved": "https://registry.npmjs.org/access-control/-/access-control-1.0.1.tgz",
+      "integrity": "sha512-H5aqjkogmFxfaOrfn/e42vyspHVXuJ8er63KuljJXpOyJ1ZO/U5CrHfO8BLKIy2w7mBM02L5quL0vbfQqrGQbA==",
       "requires": {
         "millisecond": "~0.1.2",
         "setheader": "~1.0.0",
@@ -155,14 +126,14 @@
       }
     },
     "acorn": {
-      "version": "5.7.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/acorn/-/acorn-5.7.2.tgz",
-      "integrity": "sha1-kfqHGINIXQZwiAAxhATnK/sm3MU=",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
       "dev": true
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/acorn-jsx/-/acorn-jsx-3.0.1.tgz?dl=https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
@@ -171,7 +142,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/acorn/-/acorn-3.3.0.tgz?dl=https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -179,12 +150,12 @@
     },
     "after": {
       "version": "0.8.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/after/-/after-0.8.2.tgz?dl=https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "ajv": {
       "version": "5.5.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ajv/-/ajv-5.5.2.tgz?dl=https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
         "co": "^4.6.0",
@@ -195,31 +166,31 @@
     },
     "ajv-keywords": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ajv-keywords/-/ajv-keywords-2.1.1.tgz?dl=https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-escapes/-/ansi-escapes-3.1.0.tgz?dl=https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha1-9zIHu4EgfXX9bIPxJa8m7qN4yjA=",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-regex/-/ansi-regex-2.1.1.tgz?dl=https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-styles/-/ansi-styles-2.2.1.tgz?dl=https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/argparse/-/argparse-1.0.10.tgz?dl=https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -227,12 +198,18 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/array-flatten/-/array-flatten-1.1.1.tgz?dl=https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
     },
     "array-includes": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/array-includes/-/array-includes-3.0.3.tgz?dl=https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
@@ -242,7 +219,7 @@
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/array-union/-/array-union-1.0.2.tgz?dl=https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
@@ -251,54 +228,42 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/array-uniq/-/array-uniq-1.0.3.tgz?dl=https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/arrify/-/arrify-1.0.1.tgz?dl=https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "ascli": {
       "version": "0.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ascli/-/ascli-0.3.0.tgz?dl=https://registry.npmjs.org/ascli/-/ascli-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ascli/-/ascli-0.3.0.tgz",
       "integrity": "sha1-XmYjDlIZ/j6JUqTvtPIPrllqgTo=",
       "requires": {
         "colour": "^0.7.1",
         "optjs": "^3.2.2"
-      },
-      "dependencies": {
-        "colour": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
-          "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
-        },
-        "optjs": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
-          "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
-        }
       }
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/assert-plus/-/assert-plus-1.0.0.tgz?dl=https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assume": {
       "version": "1.5.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/assume/-/assume-1.5.2.tgz?dl=https://registry.npmjs.org/assume/-/assume-1.5.2.tgz",
-      "integrity": "sha1-BXxaLzPOfRzNjXg9stXQmMrN0RE=",
+      "resolved": "https://registry.npmjs.org/assume/-/assume-1.5.2.tgz",
+      "integrity": "sha512-/IDWcpPTGjUsf4lcMi837n3xFxkEBVEfVxOvYUgdU3y6FjWSWzXiUzFAYlulr94kr79mNbiOFC5isJmaQn2C2w==",
       "dev": true,
       "requires": {
         "deep-eql": "0.1.x",
@@ -310,24 +275,24 @@
     },
     "assume-sinon": {
       "version": "0.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/assume-sinon/-/assume-sinon-0.0.0.tgz?dl=https://registry.npmjs.org/assume-sinon/-/assume-sinon-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assume-sinon/-/assume-sinon-0.0.0.tgz",
       "integrity": "sha1-lp3UYTmlgaqc6vy5COg1K/p+Z+E=",
       "dev": true
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/async/-/async-1.5.2.tgz?dl=https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/asynckit/-/asynckit-0.4.0.tgz?dl=https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "authboot": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/authboot/-/authboot-2.0.1.tgz",
-      "integrity": "sha1-UkySX3ybvDmeiLNc/Bmv4gduaGc=",
+      "resolved": "https://registry.npmjs.org/authboot/-/authboot-2.0.1.tgz",
+      "integrity": "sha512-+a2TnxRBMpWCyTA0QR8qczkT5n012RbuHEVJ+n9Z7fH9vWhsn/RZflxrbF0lv3sZb5Tm3/TAaq3iSSAd+3bLUw==",
       "requires": {
         "diagnostics": "^1.1.0",
         "express-basic-auth-safe": "^1.1.4"
@@ -335,7 +300,7 @@
     },
     "aws-sdk": {
       "version": "2.50.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/aws-sdk/-/aws-sdk-2.50.0.tgz?dl=https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.50.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.50.0.tgz",
       "integrity": "sha1-ayhVdB+O/gZPgko9sL9PO8W94Bg=",
       "requires": {
         "buffer": "5.0.6",
@@ -349,9 +314,14 @@
         "xmlbuilder": "4.2.1"
       },
       "dependencies": {
+        "uuid": {
+          "version": "3.0.1",
+          "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+        },
         "xml2js": {
           "version": "0.4.17",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/xml2js/-/xml2js-0.4.17.tgz?dl=https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
           "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
           "requires": {
             "sax": ">=0.6.0",
@@ -362,17 +332,17 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/aws-sign2/-/aws-sign2-0.7.0.tgz?dl=https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.8.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/babel-code-frame/-/babel-code-frame-6.26.0.tgz?dl=https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
@@ -383,7 +353,7 @@
     },
     "babel-eslint": {
       "version": "6.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/babel-eslint/-/babel-eslint-6.1.2.tgz?dl=https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
       "integrity": "sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8=",
       "dev": true,
       "requires": {
@@ -396,7 +366,7 @@
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/babel-messages/-/babel-messages-6.23.0.tgz?dl=https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
@@ -405,7 +375,7 @@
     },
     "babel-runtime": {
       "version": "6.26.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/babel-runtime/-/babel-runtime-6.26.0.tgz?dl=https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
@@ -415,7 +385,7 @@
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/babel-traverse/-/babel-traverse-6.26.0.tgz?dl=https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
@@ -430,26 +400,17 @@
         "lodash": "^4.17.4"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/debug/-/debug-2.6.9.tgz?dl=https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash/-/lodash-4.17.10.tgz?dl=https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
         }
       }
     },
     "babel-types": {
       "version": "6.26.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/babel-types/-/babel-types-6.26.0.tgz?dl=https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
@@ -460,37 +421,37 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash/-/lodash-4.17.10.tgz?dl=https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
         }
       }
     },
     "babylon": {
       "version": "6.18.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/babylon/-/babylon-6.18.0.tgz?dl=https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "backo": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/backo/-/backo-1.1.0.tgz?dl=https://registry.npmjs.org/backo/-/backo-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/backo/-/backo-1.1.0.tgz",
       "integrity": "sha1-o2xEaJI/LSZcnopwnqVuza/4B+Y="
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/balanced-match/-/balanced-match-1.0.0.tgz?dl=https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/base64-js/-/base64-js-1.3.0.tgz?dl=https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha1-yrHmEY8FEJXli1KBrqjBzSK/wOM="
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "base64url": {
       "version": "1.0.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/base64url/-/base64url-1.0.6.tgz?dl=https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
       "integrity": "sha1-1k03XWinxkDZEuI1jRcNylu1RoE=",
       "requires": {
         "concat-stream": "~1.4.7",
@@ -499,8 +460,8 @@
       "dependencies": {
         "concat-stream": {
           "version": "1.4.11",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/concat-stream/-/concat-stream-1.4.11.tgz?dl=https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.11.tgz",
-          "integrity": "sha1-Hcn2ZvJiHanGGLHn+POy/3C1928=",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.11.tgz",
+          "integrity": "sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw==",
           "requires": {
             "inherits": "~2.0.1",
             "readable-stream": "~1.1.9",
@@ -509,12 +470,12 @@
         },
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isarray/-/isarray-0.0.1.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-1.1.14.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -522,25 +483,27 @@
             "isarray": "0.0.1",
             "string_decoder": "~0.10.x"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-0.10.31.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "basic-auth": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/basic-auth/-/basic-auth-2.0.0.tgz?dl=https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
-      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
@@ -549,8 +512,8 @@
     },
     "bffs": {
       "version": "5.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bffs/-/bffs-5.1.1.tgz?dl=https://registry.npmjs.org/bffs/-/bffs-5.1.1.tgz",
-      "integrity": "sha1-6dzJEsks2WamjX9jGcIehk3B4WE=",
+      "resolved": "https://registry.npmjs.org/bffs/-/bffs-5.1.1.tgz",
+      "integrity": "sha512-2pdpxIoxK3zbeGxHaKMJVfKdta8tnyLxLvil0X7gsnLMSNj/Cb5AE+YNtJAxgwPF4Gbp5Ns/IMuvHpiPf90E2g==",
       "requires": {
         "async": "1.4.x",
         "cdnup": "^2.5.0",
@@ -567,17 +530,42 @@
       "dependencies": {
         "async": {
           "version": "1.4.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/async/-/async-1.4.2.tgz?dl=https://registry.npmjs.org/async/-/async-1.4.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.4.2.tgz",
           "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs="
         },
         "hyperquest": {
           "version": "2.1.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hyperquest/-/hyperquest-2.1.3.tgz?dl=https://registry.npmjs.org/hyperquest/-/hyperquest-2.1.3.tgz",
-          "integrity": "sha1-UjEn16NDGBtAvzJOIx0ldu31JjM=",
+          "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-2.1.3.tgz",
+          "integrity": "sha512-fUuDOrB47PqNK/BAMOS13v41UoaqIxqSLHX6CAbOD7OfT+/GCWO1/vPLfTNutOeXrv1ikuaZ3yux+33Z9vh+rw==",
           "requires": {
             "buffer-from": "^0.1.1",
             "duplexer2": "~0.0.2",
             "through2": "~0.6.3"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -610,6 +598,11 @@
             "util-deprecate": "~1.0.1"
           }
         },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -622,7 +615,7 @@
     },
     "block-stream": {
       "version": "0.0.9",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/block-stream/-/block-stream-0.0.9.tgz?dl=https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
         "inherits": "~2.0.0"
@@ -630,7 +623,7 @@
     },
     "bluebird": {
       "version": "2.11.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bluebird/-/bluebird-2.11.0.tgz?dl=https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
     },
     "body-parser": {
@@ -650,11 +643,6 @@
         "type-is": "~1.6.16"
       },
       "dependencies": {
-        "bytes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-        },
         "qs": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -664,16 +652,23 @@
     },
     "boom": {
       "version": "0.4.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/boom/-/boom-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "requires": {
         "hoek": "0.9.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
+        }
       }
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/brace-expansion/-/brace-expansion-1.1.11.tgz?dl=https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -681,7 +676,7 @@
     },
     "broadway": {
       "version": "3.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/broadway/-/broadway-3.1.1.tgz?dl=https://registry.npmjs.org/broadway/-/broadway-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/broadway/-/broadway-3.1.1.tgz",
       "integrity": "sha1-F2UCLJYPEHzYYZF/ndFlCaQk7AY=",
       "requires": {
         "create-servers": "^2.0.0",
@@ -691,13 +686,13 @@
     },
     "browser-request": {
       "version": "0.3.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/browser-request/-/browser-request-0.3.3.tgz?dl=https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
       "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc=",
       "dev": true
     },
     "buffer": {
       "version": "5.0.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/buffer/-/buffer-5.0.6.tgz?dl=https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz",
       "integrity": "sha1-LqZp9+7Atu2gWwj4tf9mGyhXNYg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -706,27 +701,27 @@
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz?dl=https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/buffer-from/-/buffer-from-0.1.2.tgz?dl=https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-      "integrity": "sha1-FfS5vO8BIETfMRQsFDM8r24CYNA="
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
     },
     "buffer-shims": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/buffer-shims/-/buffer-shims-1.0.0.tgz?dl=https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
     },
     "bufferview": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bufferview/-/bufferview-1.0.1.tgz?dl=https://registry.npmjs.org/bufferview/-/bufferview-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/bufferview/-/bufferview-1.0.1.tgz",
       "integrity": "sha1-ev10pF+Tf6QiodM4wIu/3HbNcl0="
     },
     "bytebuffer": {
       "version": "3.5.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bytebuffer/-/bytebuffer-3.5.5.tgz?dl=https://registry.npmjs.org/bytebuffer/-/bytebuffer-3.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-3.5.5.tgz",
       "integrity": "sha1-em+vGhNRSwg/H8+VQcTJv75+f9M=",
       "requires": {
         "bufferview": "~1",
@@ -734,13 +729,13 @@
       }
     },
     "bytes": {
-      "version": "2.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bytes/-/bytes-2.4.0.tgz?dl=https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-      "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "caller-path": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/caller-path/-/caller-path-0.1.0.tgz?dl=https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
@@ -749,18 +744,18 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/callsites/-/callsites-0.2.0.tgz?dl=https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "camelcase": {
       "version": "1.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/camelcase/-/camelcase-1.2.1.tgz?dl=https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
     },
     "camelcase-keys": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/camelcase-keys/-/camelcase-keys-1.0.0.tgz?dl=https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
       "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
       "requires": {
         "camelcase": "^1.0.1",
@@ -769,7 +764,7 @@
     },
     "carpenterd-api-client": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/carpenterd-api-client/-/carpenterd-api-client-1.4.0.tgz?dl=https://registry.npmjs.org/carpenterd-api-client/-/carpenterd-api-client-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/carpenterd-api-client/-/carpenterd-api-client-1.4.0.tgz",
       "integrity": "sha1-Ybdjxwh6vNGj3wf5VLwRUEGkNPg=",
       "requires": {
         "hyperquest": "~2.1.1"
@@ -777,33 +772,58 @@
       "dependencies": {
         "hyperquest": {
           "version": "2.1.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hyperquest/-/hyperquest-2.1.3.tgz?dl=https://registry.npmjs.org/hyperquest/-/hyperquest-2.1.3.tgz",
-          "integrity": "sha1-UjEn16NDGBtAvzJOIx0ldu31JjM=",
+          "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-2.1.3.tgz",
+          "integrity": "sha512-fUuDOrB47PqNK/BAMOS13v41UoaqIxqSLHX6CAbOD7OfT+/GCWO1/vPLfTNutOeXrv1ikuaZ3yux+33Z9vh+rw==",
           "requires": {
             "buffer-from": "^0.1.1",
             "duplexer2": "~0.0.2",
             "through2": "~0.6.3"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/caseless/-/caseless-0.12.0.tgz?dl=https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "cassandra-driver": {
       "version": "3.5.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cassandra-driver/-/cassandra-driver-3.5.0.tgz?dl=https://registry.npmjs.org/cassandra-driver/-/cassandra-driver-3.5.0.tgz",
-      "integrity": "sha1-VoSKpNuo1otb4ufUfNNHWXRl5qY=",
+      "resolved": "https://registry.npmjs.org/cassandra-driver/-/cassandra-driver-3.5.0.tgz",
+      "integrity": "sha512-CBdXA5roCZOvXElO+jTVWsa8W231fpYcGU+R1QQ1yO9O9dpXdZ7vkPpUfc+LO47Dyp67FNWYS+mm/q2ZMPJrZQ==",
       "requires": {
         "long": "^2.2.0"
       }
     },
     "cdnup": {
       "version": "2.5.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cdnup/-/cdnup-2.5.0.tgz?dl=https://registry.npmjs.org/cdnup/-/cdnup-2.5.0.tgz",
-      "integrity": "sha1-6/f46o1wqmgE1CVzm9r0igbqVO8=",
+      "resolved": "https://registry.npmjs.org/cdnup/-/cdnup-2.5.0.tgz",
+      "integrity": "sha512-tmw8SnfgMWzSldcRqOght9IUqBuCl2qtejZq15Zb2cup73FpnEYxfq13Wre5aZC0CCV817Nu11wllIFmGlvnSg==",
       "requires": {
         "backo": "~1.1.0",
         "diagnostics": "1.0.x",
@@ -817,7 +837,7 @@
       "dependencies": {
         "color": {
           "version": "0.8.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/color/-/color-0.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
           "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
           "requires": {
             "color-convert": "^0.5.0",
@@ -826,12 +846,12 @@
         },
         "color-convert": {
           "version": "0.5.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/color-convert/-/color-convert-0.5.3.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
           "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
         },
         "color-string": {
           "version": "0.3.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/color-string/-/color-string-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
           "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
           "requires": {
             "color-name": "^1.0.0"
@@ -839,12 +859,12 @@
         },
         "colornames": {
           "version": "0.0.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/colornames/-/colornames-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
           "integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE="
         },
         "colorspace": {
           "version": "1.0.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/colorspace/-/colorspace-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
           "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
           "requires": {
             "color": "0.8.x",
@@ -853,7 +873,7 @@
         },
         "diagnostics": {
           "version": "1.0.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/diagnostics/-/diagnostics-1.0.1.tgz?dl=https://registry.npmjs.org/diagnostics/-/diagnostics-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.0.1.tgz",
           "integrity": "sha1-rM2wgMgrsl0N1zQwqeaof7tDFUE=",
           "requires": {
             "colorspace": "1.0.x",
@@ -863,27 +883,22 @@
         },
         "kuler": {
           "version": "0.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/kuler/-/kuler-0.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
           "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
           "requires": {
             "colornames": "0.0.2"
           }
         },
-        "mime": {
-          "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-          "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
-        },
         "text-hex": {
           "version": "0.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/text-hex/-/text-hex-0.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
           "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM="
         }
       }
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/chalk/-/chalk-1.1.3.tgz?dl=https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -896,19 +911,19 @@
     },
     "chardet": {
       "version": "0.4.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/chardet/-/chardet-0.4.2.tgz?dl=https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/circular-json/-/circular-json-0.3.3.tgz?dl=https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cli/-/cli-1.0.1.tgz?dl=https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
       "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
       "dev": true,
       "requires": {
@@ -918,7 +933,7 @@
     },
     "cli-cursor": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cli-cursor/-/cli-cursor-2.1.0.tgz?dl=https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
@@ -927,13 +942,13 @@
     },
     "cli-width": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cli-width/-/cli-width-2.2.0.tgz?dl=https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
       "version": "3.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cliui/-/cliui-3.2.0.tgz?dl=https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "requires": {
         "string-width": "^1.0.1",
@@ -943,13 +958,13 @@
     },
     "clone": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/clone/-/clone-1.0.4.tgz?dl=https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
     "cloudant-follow": {
       "version": "0.17.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cloudant-follow/-/cloudant-follow-0.17.0.tgz?dl=https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.17.0.tgz",
-      "integrity": "sha1-hCUTp05yxEDmHcK2/Zbu29nO84o=",
+      "resolved": "http://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.17.0.tgz",
+      "integrity": "sha512-JQ1xvKAHh8rsnSVBjATLCjz/vQw1sWBGadxr2H69yFMwD7hShUGDwwEefdypaxroUJ/w6t1cSwilp/hRUxEW8w==",
       "dev": true,
       "requires": {
         "browser-request": "~0.3.0",
@@ -958,104 +973,64 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/debug/-/debug-3.1.0.tgz?dl=https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.88.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/request/-/request-2.88.0.tgz",
-          "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/safe-buffer/-/safe-buffer-5.1.2.tgz?dl=https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
       }
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/co/-/co-4.6.0.tgz?dl=https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/code-point-at/-/code-point-at-1.1.0.tgz?dl=https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "coffee-script": {
       "version": "1.12.7",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/coffee-script/-/coffee-script-1.12.7.tgz?dl=https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha1-wF2uDLeVkdBbMHCoQzqYyaiczFM=",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
       "dev": true
     },
     "color": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/color/-/color-3.0.0.tgz",
-      "integrity": "sha1-2SC0Mo1TSjrIKV1o971LpsQnvpo=",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.2"
       }
     },
     "color-convert": {
-      "version": "1.9.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/color-convert/-/color-convert-1.9.2.tgz",
-      "integrity": "sha1-SYgbj7pn3xKpa98/VsCqueeRMUc=",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "requires": {
-        "color-name": "1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/color-string/-/color-string-1.5.3.tgz",
-      "integrity": "sha1-ybvF8BtYtUkvPWhXRZy2WQziBMw=",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -1063,51 +1038,56 @@
     },
     "colornames": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/colornames/-/colornames-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
       "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
     },
     "colors": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/colors/-/colors-1.0.3.tgz?dl=https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "colorspace": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/colorspace/-/colorspace-1.1.1.tgz",
-      "integrity": "sha1-msJJHhvG+PtpDiF2gU+NCRY22XI=",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.1.tgz",
+      "integrity": "sha512-pI3btWyiuz7Ken0BWh9Elzsmv2bM9AhA7psXib4anUXy/orfZ/E0MbQwhSOG/9L8hLlalqrU0UhOuqxW1YjmVw==",
       "requires": {
         "color": "3.0.x",
         "text-hex": "1.0.x"
       }
     },
+    "colour": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
+    },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/combined-stream/-/combined-stream-1.0.6.tgz?dl=https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/commander/-/commander-2.3.0.tgz?dl=https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
       "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
       "dev": true
     },
     "commenting": {
       "version": "1.0.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/commenting/-/commenting-1.0.5.tgz?dl=https://registry.npmjs.org/commenting/-/commenting-1.0.5.tgz",
-      "integrity": "sha1-MQTVQsrIpPJ7PVFDj0uAQx/kUms="
+      "resolved": "https://registry.npmjs.org/commenting/-/commenting-1.0.5.tgz",
+      "integrity": "sha512-U7qGbcDLSNpOcV3RQRKHp7hFpy9WUmfawbkPdS4R2RhrSu4dOF85QQpx/Zjcv7uLF6tWSUKEKUIkxknPCrVjwg=="
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/concat-map/-/concat-map-0.0.1.tgz?dl=https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/concat-stream/-/concat-stream-1.6.2.tgz?dl=https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -1117,14 +1097,14 @@
       "dependencies": {
         "buffer-from": {
           "version": "1.1.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/buffer-from/-/buffer-from-1.1.1.tgz",
-          "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
         }
       }
     },
     "connect": {
       "version": "3.6.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/connect/-/connect-3.6.6.tgz?dl=https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
       "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
       "dev": true,
       "requires": {
@@ -1134,18 +1114,9 @@
         "utils-merge": "1.0.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/debug/-/debug-2.6.9.tgz?dl=https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "finalhandler": {
           "version": "1.1.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/finalhandler/-/finalhandler-1.1.0.tgz?dl=https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
           "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
           "dev": true,
           "requires": {
@@ -1160,7 +1131,7 @@
         },
         "statuses": {
           "version": "1.3.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/statuses/-/statuses-1.3.1.tgz?dl=https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
           "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
           "dev": true
         }
@@ -1168,12 +1139,12 @@
     },
     "connected": {
       "version": "0.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/connected/-/connected-0.0.2.tgz?dl=https://registry.npmjs.org/connected/-/connected-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/connected/-/connected-0.0.2.tgz",
       "integrity": "sha1-e1dVshbOMf+rzMOOn04d/Bw7fG0="
     },
     "console-browserify": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/console-browserify/-/console-browserify-1.1.0.tgz?dl=https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
@@ -1182,22 +1153,22 @@
     },
     "content-disposition": {
       "version": "0.5.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/content-disposition/-/content-disposition-0.5.2.tgz?dl=https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/content-type/-/content-type-1.0.4.tgz?dl=https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
       "version": "0.3.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cookie/-/cookie-0.3.1.tgz?dl=https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-parser": {
       "version": "1.4.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cookie-parser/-/cookie-parser-1.4.3.tgz?dl=https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
       "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
       "requires": {
         "cookie": "0.3.1",
@@ -1206,23 +1177,23 @@
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cookie-signature/-/cookie-signature-1.0.6.tgz?dl=https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-js": {
       "version": "2.5.7",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha1-+XJgj/DOrWi4QaFqky0LGDeRgU4=",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/core-util-is/-/core-util-is-1.0.2.tgz?dl=https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "couchapp": {
       "version": "0.11.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/couchapp/-/couchapp-0.11.0.tgz?dl=https://registry.npmjs.org/couchapp/-/couchapp-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/couchapp/-/couchapp-0.11.0.tgz",
       "integrity": "sha1-8J3DFdYQ9vbnn9DK9eXWJLDMeD4=",
       "dev": true,
       "requires": {
@@ -1237,13 +1208,13 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/colors/-/colors-0.6.2.tgz?dl=https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "http-proxy": {
           "version": "0.8.7",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/http-proxy/-/http-proxy-0.8.7.tgz?dl=https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.7.tgz",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.7.tgz",
           "integrity": "sha1-p7xThhgJLNJu0ZHkYlkzuu9t6A4=",
           "dev": true,
           "requires": {
@@ -1256,24 +1227,17 @@
     },
     "create-servers": {
       "version": "2.6.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/create-servers/-/create-servers-2.6.0.tgz",
-      "integrity": "sha1-7G0kkhzdMTajJHSspivbwdfI7Jc=",
+      "resolved": "https://registry.npmjs.org/create-servers/-/create-servers-2.6.0.tgz",
+      "integrity": "sha512-BCsFrkVc4MrM9fsL2KJDGmXH2mHkl9QzZ5AJ15/Cj6KuyyNQcLYAkGiO4UMC7wl0L9waLhsXqeGxYoSuk72oTw==",
       "requires": {
         "connected": "~0.0.2",
         "errs": "~0.3.0",
         "object-assign": "^4.1.0"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        }
       }
     },
     "cross-spawn": {
       "version": "5.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cross-spawn/-/cross-spawn-5.1.0.tgz?dl=https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
@@ -1284,8 +1248,8 @@
       "dependencies": {
         "lru-cache": {
           "version": "4.1.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lru-cache/-/lru-cache-4.1.3.tgz?dl=https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -1296,7 +1260,7 @@
     },
     "cryptiles": {
       "version": "0.2.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cryptiles/-/cryptiles-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
       "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
       "optional": true,
       "requires": {
@@ -1305,28 +1269,28 @@
     },
     "crypto-browserify": {
       "version": "1.0.9",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/crypto-browserify/-/crypto-browserify-1.0.9.tgz?dl=https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
+      "resolved": "http://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
       "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA="
     },
     "ctype": {
       "version": "0.5.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ctype/-/ctype-0.5.3.tgz?dl=https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
       "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
       "optional": true
     },
     "cycle": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cycle/-/cycle-1.0.3.tgz?dl=https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "cyclist": {
       "version": "0.2.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cyclist/-/cyclist-0.2.2.tgz?dl=https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/dashdash/-/dashdash-1.14.1.tgz?dl=https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -1352,32 +1316,11 @@
         "to-snake-case": "^1.0.0",
         "understudy": "^4.1.0",
         "uuid": "^2.0.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2/-/through2-2.0.3.tgz?dl=https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
-          }
-        },
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-2.0.3.tgz?dl=https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-        }
       }
     },
     "datastar-test-tools": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/datastar-test-tools/-/datastar-test-tools-1.0.0.tgz?dl=https://registry.npmjs.org/datastar-test-tools/-/datastar-test-tools-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/datastar-test-tools/-/datastar-test-tools-1.0.0.tgz",
       "integrity": "sha1-5INqrN/Opp8Gk1Qcv2tQYLcXrUs=",
       "dev": true,
       "requires": {
@@ -1390,7 +1333,7 @@
       "dependencies": {
         "datastar": {
           "version": "1.1.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/datastar/-/datastar-1.1.0.tgz?dl=https://registry.npmjs.org/datastar/-/datastar-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/datastar/-/datastar-1.1.0.tgz",
           "integrity": "sha1-sfehxiyo5OHy68SVycp0ZpjHJjs=",
           "dev": true,
           "requires": {
@@ -1409,40 +1352,18 @@
             "understudy": "^4.1.0",
             "uuid": "^2.0.1"
           }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2/-/through2-2.0.3.tgz?dl=https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
-          }
-        },
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-2.0.3.tgz?dl=https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-          "dev": true
         }
       }
     },
     "date-now": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/date-now/-/date-now-0.1.4.tgz?dl=https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
     "debra": {
       "version": "1.8.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/debra/-/debra-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/debra/-/debra-1.8.0.tgz",
       "integrity": "sha1-HQpo8V6vWNtz3wX+grszfwFBsLI=",
       "requires": {
         "basic-auth": "~1.0.4",
@@ -1454,12 +1375,12 @@
       "dependencies": {
         "basic-auth": {
           "version": "1.0.4",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/basic-auth/-/basic-auth-1.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz",
           "integrity": "sha1-Awk1sB3nyblKgksp8/zLdQ06UpA="
         },
         "debug": {
           "version": "2.2.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/debug/-/debug-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "requires": {
             "ms": "0.7.1"
@@ -1467,7 +1388,7 @@
         },
         "ms": {
           "version": "0.7.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ms/-/ms-0.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
         }
       }
@@ -1482,12 +1403,12 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/decamelize/-/decamelize-1.2.0.tgz?dl=https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deep-eql": {
       "version": "0.1.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/deep-eql/-/deep-eql-0.1.3.tgz?dl=https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
       "requires": {
@@ -1496,25 +1417,25 @@
     },
     "deep-equal": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/deep-equal/-/deep-equal-0.2.1.tgz?dl=https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz",
       "integrity": "sha1-+tenkyJMvww8d4b5LveA5PyMyHg=",
       "dev": true
     },
     "deep-extend": {
       "version": "0.4.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/deep-extend/-/deep-extend-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/deep-is/-/deep-is-0.1.3.tgz?dl=https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
@@ -1522,7 +1443,7 @@
     },
     "del": {
       "version": "2.2.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/del/-/del-2.2.2.tgz?dl=https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
@@ -1533,40 +1454,32 @@
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0",
         "rimraf": "^2.2.8"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
       }
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/delayed-stream/-/delayed-stream-1.0.0.tgz?dl=https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "demolish": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/demolish/-/demolish-1.0.2.tgz?dl=https://registry.npmjs.org/demolish/-/demolish-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/demolish/-/demolish-1.0.2.tgz",
       "integrity": "sha1-VFDAsNrIUNjYL/c4h2/Tz5C+UPE="
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/depd/-/depd-1.1.2.tgz?dl=https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/destroy/-/destroy-1.0.4.tgz?dl=https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "diagnostics": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/diagnostics/-/diagnostics-1.1.1.tgz",
-      "integrity": "sha1-yrasM99wydmnJ0kK5DrJladpsio=",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
       "requires": {
         "colorspace": "1.1.x",
         "enabled": "1.0.x",
@@ -1575,14 +1488,14 @@
     },
     "diff": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/diff/-/diff-1.4.0.tgz?dl=https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
       "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
       "dev": true
     },
     "doctrine": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/doctrine/-/doctrine-2.1.0.tgz?dl=https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -1590,7 +1503,7 @@
     },
     "dom-serializer": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/dom-serializer/-/dom-serializer-0.1.0.tgz?dl=https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
@@ -1600,13 +1513,13 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/domelementtype/-/domelementtype-1.1.3.tgz?dl=https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         },
         "entities": {
           "version": "1.1.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/entities/-/entities-1.1.1.tgz?dl=https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
           "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
           "dev": true
         }
@@ -1614,13 +1527,13 @@
     },
     "domelementtype": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/domelementtype/-/domelementtype-1.3.0.tgz?dl=https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
       "dev": true
     },
     "domhandler": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/domhandler/-/domhandler-2.3.0.tgz?dl=https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
@@ -1629,7 +1542,7 @@
     },
     "domutils": {
       "version": "1.5.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/domutils/-/domutils-1.5.1.tgz?dl=https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
@@ -1639,12 +1552,12 @@
     },
     "double-ended-queue": {
       "version": "2.1.0-0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz?dl=https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "duplexer2": {
       "version": "0.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/duplexer2/-/duplexer2-0.0.2.tgz?dl=https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "requires": {
         "readable-stream": "~1.1.9"
@@ -1652,12 +1565,12 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isarray/-/isarray-0.0.1.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-1.1.14.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -1665,18 +1578,13 @@
             "isarray": "0.0.1",
             "string_decoder": "~0.10.x"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-0.10.31.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "duplexify": {
       "version": "3.6.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/duplexify/-/duplexify-3.6.0.tgz?dl=https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
-      "integrity": "sha1-WSkD9dgLONA3IgVBJk1poZj7NBA=",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -1686,7 +1594,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "optional": true,
       "requires": {
@@ -1696,7 +1604,7 @@
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.10",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz?dl=https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -1704,12 +1612,12 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ee-first/-/ee-first-1.1.1.tgz?dl=https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/enabled/-/enabled-1.0.2.tgz?dl=https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "requires": {
         "env-variable": "0.0.x"
@@ -1717,37 +1625,37 @@
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/encodeurl/-/encodeurl-1.0.2.tgz?dl=https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "1.4.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/end-of-stream/-/end-of-stream-1.4.1.tgz?dl=https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "^1.4.0"
       }
     },
     "entities": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/entities/-/entities-1.0.0.tgz?dl=https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
       "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
       "dev": true
     },
     "env-variable": {
       "version": "0.0.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/env-variable/-/env-variable-0.0.4.tgz?dl=https://registry.npmjs.org/env-variable/-/env-variable-0.0.4.tgz",
-      "integrity": "sha1-DWKAz1B9hCQr7+NaUSta5L53xU4="
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.4.tgz",
+      "integrity": "sha512-+jpGxSWG4vr6gVxUHOc4p+ilPnql7NzZxOZBxNldsKGjCF+97df3CbuX7XMaDa5oAVkKQj4rKp38rYdC4VcpDg=="
     },
     "errs": {
       "version": "0.3.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/errs/-/errs-0.3.2.tgz?dl=https://registry.npmjs.org/errs/-/errs-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/errs/-/errs-0.3.2.tgz",
       "integrity": "sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk="
     },
     "es-abstract": {
       "version": "1.12.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/es-abstract/-/es-abstract-1.12.0.tgz",
-      "integrity": "sha1-nbvdJ8aFbwABQhyhh4LXhr+KYWU=",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.1.1",
@@ -1758,38 +1666,38 @@
       }
     },
     "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/es-to-primitive/-/es-to-primitive-1.1.1.tgz?dl=https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
+        "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-symbol": "^1.0.2"
       }
     },
     "es6-promise": {
-      "version": "4.2.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha1-3EIhwrFlGHYL2MOaUtjzVvwA7Sk=",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
       "dev": true,
       "optional": true
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/escape-html/-/escape-html-1.0.3.tgz?dl=https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz?dl=https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "eslint": {
       "version": "4.19.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/eslint/-/eslint-4.19.1.tgz?dl=https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-      "integrity": "sha1-MtHWU+HZBAiFS/spbwdux+GGowA=",
+      "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
         "ajv": "^5.3.0",
@@ -1834,14 +1742,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-regex/-/ansi-regex-3.0.0.tgz?dl=https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-styles/-/ansi-styles-3.2.1.tgz?dl=https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -1849,8 +1757,8 @@
         },
         "chalk": {
           "version": "2.4.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/chalk/-/chalk-2.4.1.tgz?dl=https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -1859,29 +1767,35 @@
           }
         },
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/debug/-/debug-3.1.0.tgz?dl=https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "globals": {
           "version": "11.7.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/globals/-/globals-11.7.0.tgz",
-          "integrity": "sha1-pYP6pDBVsayncZFL9oJY4vwSVnM=",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
           "dev": true
         },
         "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash/-/lodash-4.17.10.tgz?dl=https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-ansi/-/strip-ansi-4.0.0.tgz?dl=https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -1890,8 +1804,8 @@
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -1901,8 +1815,8 @@
     },
     "eslint-config-godaddy": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/eslint-config-godaddy/-/eslint-config-godaddy-2.1.0.tgz?dl=https://registry.npmjs.org/eslint-config-godaddy/-/eslint-config-godaddy-2.1.0.tgz",
-      "integrity": "sha1-ogzpmZr7whXwz2pbIcvOjO5sxq0=",
+      "resolved": "https://registry.npmjs.org/eslint-config-godaddy/-/eslint-config-godaddy-2.1.0.tgz",
+      "integrity": "sha512-K2axE1p1ucObtVBoVY7wqw9vsp8CM1nSn2wk/NboHIfHvDJrG+4Q7yaWFkLlBXT37ojHozqytQlxvi09GFrg+Q==",
       "dev": true,
       "requires": {
         "which": "^1.2.12"
@@ -1910,8 +1824,8 @@
     },
     "eslint-config-godaddy-react": {
       "version": "2.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/eslint-config-godaddy-react/-/eslint-config-godaddy-react-2.2.1.tgz",
-      "integrity": "sha1-p07PNcHSoah5c6hTxACTJZsTB1s=",
+      "resolved": "https://registry.npmjs.org/eslint-config-godaddy-react/-/eslint-config-godaddy-react-2.2.1.tgz",
+      "integrity": "sha512-4iQHC09c+4iLWaSJq58kOACiKCHDU6z3B7dZBFxFvR5phk83ZBHwxaoUsHDvzpXY/vfiq3Ga1cFAKKwHj3sWpg==",
       "dev": true,
       "requires": {
         "eslint-config-godaddy": "^2.0.0"
@@ -1919,8 +1833,8 @@
     },
     "eslint-plugin-json": {
       "version": "1.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/eslint-plugin-json/-/eslint-plugin-json-1.2.1.tgz",
-      "integrity": "sha1-pNbstZscPNxgCNKTcI6dV8NcULA=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-1.2.1.tgz",
+      "integrity": "sha512-7/8a+rwJLI5gq1ofZi33FmaDlRc49h3hkoHKE0SejSN3W8nmEzggeaI/MUWnxjHyVaPjvlzZxdpoMOCywLHDyA==",
       "dev": true,
       "requires": {
         "jshint": "^2.9.6"
@@ -1928,8 +1842,8 @@
     },
     "eslint-plugin-mocha": {
       "version": "4.12.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/eslint-plugin-mocha/-/eslint-plugin-mocha-4.12.1.tgz?dl=https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-4.12.1.tgz",
-      "integrity": "sha1-26zFQ7F4tFNuxbGdf46IZNhUBL8=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-4.12.1.tgz",
+      "integrity": "sha512-hxWtYHvLA0p/PKymRfDYh9Mxt5dYkg2Goy1vZDarTEEYfELP9ksga7kKG1NUKSQy27C8Qjc7YrSWTLUhOEOksA==",
       "dev": true,
       "requires": {
         "ramda": "^0.25.0"
@@ -1937,8 +1851,8 @@
     },
     "eslint-plugin-react": {
       "version": "7.11.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
-      "integrity": "sha1-wBp69vF1GUV9YRaqlPxtLMrVRDw=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
+      "integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -1950,8 +1864,8 @@
     },
     "eslint-scope": {
       "version": "3.7.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/eslint-scope/-/eslint-scope-3.7.3.tgz",
-      "integrity": "sha1-u1ByANPRf2AkdjYWC0gmKEsQhTU=",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -1960,14 +1874,14 @@
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz?dl=https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0=",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
       "dev": true
     },
     "espree": {
       "version": "3.5.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/espree/-/espree-3.5.4.tgz?dl=https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha1-sPRHGHyKi+2US4FaZgvd9d610ac=",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
         "acorn": "^5.5.0",
@@ -1976,14 +1890,14 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esquery": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/esquery/-/esquery-1.0.1.tgz?dl=https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
@@ -1991,8 +1905,8 @@
     },
     "esrecurse": {
       "version": "4.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/esrecurse/-/esrecurse-4.2.1.tgz?dl=https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
@@ -2000,40 +1914,40 @@
     },
     "estraverse": {
       "version": "4.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/estraverse/-/estraverse-4.2.0.tgz?dl=https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/esutils/-/esutils-2.0.2.tgz?dl=https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/etag/-/etag-1.8.1.tgz?dl=https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/eventemitter2/-/eventemitter2-0.4.14.tgz?dl=https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
     },
     "eventemitter3": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/eventemitter3/-/eventemitter3-1.1.1.tgz?dl=https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
       "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/exit/-/exit-0.1.2.tgz?dl=https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "express": {
       "version": "4.16.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/express/-/express-4.16.3.tgz?dl=https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
         "accepts": "~1.3.5",
@@ -2070,7 +1984,7 @@
       "dependencies": {
         "body-parser": {
           "version": "1.18.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/body-parser/-/body-parser-1.18.2.tgz?dl=https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
           "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
           "requires": {
             "bytes": "3.0.0",
@@ -2085,32 +1999,19 @@
             "type-is": "~1.6.15"
           }
         },
-        "bytes": {
-          "version": "3.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bytes/-/bytes-3.0.0.tgz?dl=https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/debug/-/debug-2.6.9.tgz?dl=https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "iconv-lite": {
           "version": "0.4.19",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/iconv-lite/-/iconv-lite-0.4.19.tgz?dl=https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
         },
         "qs": {
           "version": "6.5.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/qs/-/qs-6.5.1.tgz?dl=https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
         },
         "raw-body": {
           "version": "2.3.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/raw-body/-/raw-body-2.3.2.tgz?dl=https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
           "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
           "requires": {
             "bytes": "3.0.0",
@@ -2121,12 +2022,12 @@
           "dependencies": {
             "depd": {
               "version": "1.1.1",
-              "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/depd/-/depd-1.1.1.tgz?dl=https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
               "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
             },
             "http-errors": {
               "version": "1.6.2",
-              "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/http-errors/-/http-errors-1.6.2.tgz?dl=https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
               "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
               "requires": {
                 "depd": "1.1.1",
@@ -2137,15 +2038,20 @@
             },
             "setprototypeof": {
               "version": "1.0.3",
-              "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/setprototypeof/-/setprototypeof-1.0.3.tgz?dl=https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
               "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
             }
           }
         },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+        },
         "statuses": {
           "version": "1.4.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/statuses/-/statuses-1.4.0.tgz?dl=https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
@@ -2156,28 +2062,28 @@
     },
     "express-basic-auth-safe": {
       "version": "1.1.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/express-basic-auth-safe/-/express-basic-auth-safe-1.1.4.tgz",
-      "integrity": "sha1-bPT8ECBvf4q47cwXg/Un/Yx8/nU=",
+      "resolved": "https://registry.npmjs.org/express-basic-auth-safe/-/express-basic-auth-safe-1.1.4.tgz",
+      "integrity": "sha512-JdgF7SE+FBGCObnGMakP45orgKhgQKSpdFarsIdPy2xgR8IGjr16qz3M8ZuWC1RVUxPKQVWtbeR+6DjR1VzXHA==",
       "requires": {
         "basic-auth": "^1.1.0"
       },
       "dependencies": {
         "basic-auth": {
           "version": "1.1.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/basic-auth/-/basic-auth-1.1.0.tgz?dl=https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
           "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ="
         }
       }
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/external-editor/-/external-editor-2.2.0.tgz?dl=https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha1-BFURz9jRM/OEZnPRBHwVTiFK09U=",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
         "chardet": "^0.4.0",
@@ -2185,19 +2091,10 @@
         "tmp": "^0.0.33"
       },
       "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
         "tmp": {
           "version": "0.0.33",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tmp/-/tmp-0.0.33.tgz?dl=https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-          "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "dev": true,
           "requires": {
             "os-tmpdir": "~1.0.2"
@@ -2207,7 +2104,7 @@
     },
     "extract-zip": {
       "version": "1.6.7",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/extract-zip/-/extract-zip-1.6.7.tgz",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
       "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
       "dev": true,
       "optional": true,
@@ -2216,59 +2113,47 @@
         "debug": "2.6.9",
         "mkdirp": "0.5.1",
         "yauzl": "2.4.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/extsprintf/-/extsprintf-1.3.0.tgz?dl=https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "eyes": {
       "version": "0.1.8",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/eyes/-/eyes-0.1.8.tgz?dl=https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "failure": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/failure/-/failure-1.1.1.tgz?dl=https://registry.npmjs.org/failure/-/failure-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/failure/-/failure-1.1.1.tgz",
       "integrity": "sha1-qOg9OxYC0kaL/2rU2QceAQO4Goc="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz?dl=https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-patch": {
       "version": "0.5.7",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fast-json-patch/-/fast-json-patch-0.5.7.tgz?dl=https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-0.5.7.tgz",
+      "resolved": "http://registry.npmjs.org/fast-json-patch/-/fast-json-patch-0.5.7.tgz",
       "integrity": "sha1-taj0nSWWJFlu+YuHLz/aiVtNhmU="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz?dl=https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz?dl=https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fd-slicer": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "optional": true,
@@ -2278,7 +2163,7 @@
     },
     "figures": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/figures/-/figures-2.0.0.tgz?dl=https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
@@ -2287,40 +2172,25 @@
     },
     "file-entry-cache": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/file-entry-cache/-/file-entry-cache-2.0.0.tgz?dl=https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
       }
     },
     "filed": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/filed/-/filed-0.1.0.tgz?dl=https://registry.npmjs.org/filed/-/filed-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/filed/-/filed-0.1.0.tgz",
       "integrity": "sha1-sPYmRyojZtwRlFN6Tup+eonzxzU=",
       "requires": {
         "mime": ">= 1.2.6"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
-        }
       }
     },
     "fill-keys": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fill-keys/-/fill-keys-1.0.2.tgz?dl=https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
       "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
       "dev": true,
       "requires": {
@@ -2330,8 +2200,8 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/finalhandler/-/finalhandler-1.1.1.tgz?dl=https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-      "integrity": "sha1-7r9O2EAHnIP0JJA4ydcDAIMBsQU=",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -2342,24 +2212,16 @@
         "unpipe": "~1.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/debug/-/debug-2.6.9.tgz?dl=https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "statuses": {
           "version": "1.4.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/statuses/-/statuses-1.4.0.tgz?dl=https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
     "flat-cache": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/flat-cache/-/flat-cache-1.3.0.tgz?dl=https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
@@ -2371,43 +2233,53 @@
     },
     "flexbuffer": {
       "version": "0.0.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/flexbuffer/-/flexbuffer-0.0.6.tgz?dl=https://registry.npmjs.org/flexbuffer/-/flexbuffer-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/flexbuffer/-/flexbuffer-0.0.6.tgz",
       "integrity": "sha1-A5/fI/iCPkQMOPMnfm/vEXQhWzA="
     },
     "fn.name": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fn.name/-/fn.name-1.0.1.tgz?dl=https://registry.npmjs.org/fn.name/-/fn.name-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.0.1.tgz",
       "integrity": "sha1-gBWtFJwQEaEWzbieukzBHZA5rdg=",
       "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/forever-agent/-/forever-agent-0.6.1.tgz?dl=https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/form-data/-/form-data-2.3.2.tgz?dl=https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
         "mime-types": "^2.1.12"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.6",
+          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        }
       }
     },
     "forwarded": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/forwarded/-/forwarded-0.1.2.tgz?dl=https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fresh/-/fresh-0.5.2.tgz?dl=https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-extra": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "dev": true,
       "optional": true,
@@ -2419,12 +2291,12 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs.realpath/-/fs.realpath-1.0.0.tgz?dl=https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fstream": {
       "version": "1.0.11",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fstream/-/fstream-1.0.11.tgz?dl=https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -2435,71 +2307,27 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/function-bind/-/function-bind-1.1.1.tgz?dl=https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz?dl=https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "gapitoken": {
       "version": "0.1.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/gapitoken/-/gapitoken-0.1.5.tgz?dl=https://registry.npmjs.org/gapitoken/-/gapitoken-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/gapitoken/-/gapitoken-0.1.5.tgz",
       "integrity": "sha1-NXf8+1Qmvjp7jrrakmcSKdjMgc4=",
       "requires": {
         "jws": "~3.0.0",
         "request": "^2.54.0"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
-        },
-        "request": {
-          "version": "2.88.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/request/-/request-2.88.0.tgz",
-          "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/safe-buffer/-/safe-buffer-5.1.2.tgz?dl=https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
-        }
       }
     },
     "gcloud": {
       "version": "0.10.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/gcloud/-/gcloud-0.10.0.tgz?dl=https://registry.npmjs.org/gcloud/-/gcloud-0.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/gcloud/-/gcloud-0.10.0.tgz",
       "integrity": "sha1-hVoms1Mdx7B5FRP/+4n8ZZIfQ+4=",
       "requires": {
         "duplexify": "^3.1.2",
@@ -2514,73 +2342,44 @@
       "dependencies": {
         "extend": {
           "version": "1.3.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/extend/-/extend-1.3.0.tgz?dl=https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
           "integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
         },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/node-uuid/-/node-uuid-1.4.8.tgz?dl=https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
-        },
-        "request": {
-          "version": "2.88.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/request/-/request-2.88.0.tgz",
-          "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          },
-          "dependencies": {
-            "extend": {
-              "version": "3.0.2",
-              "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/extend/-/extend-3.0.2.tgz",
-              "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
-            },
-            "uuid": {
-              "version": "3.3.2",
-              "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-3.3.2.tgz",
-              "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
-            }
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
           }
         },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/safe-buffer/-/safe-buffer-5.1.2.tgz?dl=https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
         }
       }
     },
     "get-stdin": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/get-stdin/-/get-stdin-4.0.1.tgz?dl=https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/getpass/-/getpass-0.1.7.tgz?dl=https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -2588,8 +2387,8 @@
     },
     "gjallarhorn": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/gjallarhorn/-/gjallarhorn-1.4.0.tgz?dl=https://registry.npmjs.org/gjallarhorn/-/gjallarhorn-1.4.0.tgz",
-      "integrity": "sha1-gWIkLFh0YHD0ZfNKugL6QvO495o=",
+      "resolved": "https://registry.npmjs.org/gjallarhorn/-/gjallarhorn-1.4.0.tgz",
+      "integrity": "sha512-z6LAxabkuVlKWeZTKjehLN4UDYjJEPjddQZXCLcmH3IHhZQTDSOFP9KxE+F4l7FdyO7Wt5I8tni2y+5EMAMS4A==",
       "requires": {
         "after": "~0.8.2",
         "diagnostics": "^1.1.0",
@@ -2602,8 +2401,8 @@
     },
     "glob": {
       "version": "7.1.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2615,13 +2414,13 @@
     },
     "globals": {
       "version": "9.18.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/globals/-/globals-9.18.0.tgz?dl=https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/globby/-/globby-5.0.0.tgz?dl=https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
@@ -2631,36 +2430,28 @@
         "object-assign": "^4.0.1",
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
       }
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/graceful-fs/-/graceful-fs-4.1.11.tgz?dl=https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "growl": {
       "version": "1.9.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/growl/-/growl-1.9.2.tgz?dl=https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/har-schema/-/har-schema-2.0.0.tgz?dl=https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/har-validator/-/har-validator-5.1.0.tgz",
-      "integrity": "sha1-RGV/VoiiLP1LckhugbOj+xF0LCk=",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "requires": {
         "ajv": "^5.3.0",
         "har-schema": "^2.0.0"
@@ -2668,15 +2459,15 @@
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/has/-/has-1.0.3.tgz",
-      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
         "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/has-ansi/-/has-ansi-2.0.0.tgz?dl=https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -2685,13 +2476,19 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/has-flag/-/has-flag-3.0.0.tgz?dl=https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "hasha": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hasha/-/hasha-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "optional": true,
@@ -2702,7 +2499,7 @@
     },
     "hawk": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hawk/-/hawk-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
       "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
       "optional": true,
       "requires": {
@@ -2710,12 +2507,20 @@
         "cryptiles": "0.2.x",
         "hoek": "0.9.x",
         "sntp": "0.2.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
+          "optional": true
+        }
       }
     },
     "hock": {
       "version": "1.3.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hock/-/hock-1.3.3.tgz",
-      "integrity": "sha1-aWHj3wUpsu08vBPkuNgfvYi5xg0=",
+      "resolved": "https://registry.npmjs.org/hock/-/hock-1.3.3.tgz",
+      "integrity": "sha512-bEX7KH/KSv2Q5zA+o1EdyeH52+gD2cfpYyAsHMEwjb9txXWttityKVf7cG0y3UVA4D8bxKDzH8LVXCQIr9rClg==",
       "dev": true,
       "requires": {
         "deep-equal": "0.2.1",
@@ -2723,13 +2528,13 @@
       }
     },
     "hoek": {
-      "version": "0.9.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hoek/-/hoek-0.9.1.tgz",
-      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "htmlparser2": {
       "version": "3.8.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/htmlparser2/-/htmlparser2-3.8.3.tgz?dl=https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
@@ -2742,13 +2547,13 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isarray/-/isarray-0.0.1.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-1.1.14.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -2757,18 +2562,12 @@
             "isarray": "0.0.1",
             "string_decoder": "~0.10.x"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-0.10.31.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
         }
       }
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/http-errors/-/http-errors-1.6.3.tgz?dl=https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -2779,7 +2578,7 @@
     },
     "http-proxy": {
       "version": "1.16.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/http-proxy/-/http-proxy-1.16.2.tgz?dl=https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
       "requires": {
         "eventemitter3": "1.x.x",
@@ -2788,7 +2587,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/http-signature/-/http-signature-1.2.0.tgz?dl=https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -2798,11 +2597,38 @@
     },
     "hyperquest": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hyperquest/-/hyperquest-1.3.0.tgz?dl=https://registry.npmjs.org/hyperquest/-/hyperquest-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.3.0.tgz",
       "integrity": "sha1-59WYAwo/wCKbYXJXg7ZBssbxeCo=",
       "requires": {
         "duplexer2": "~0.0.2",
         "through2": "~0.6.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
+        }
       }
     },
     "iconv-lite": {
@@ -2815,18 +2641,18 @@
     },
     "ieee754": {
       "version": "1.1.12",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha1-UL8k5bnIu5ivSWTJQc2wkY2ntgs="
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
     },
     "ignore": {
       "version": "3.3.10",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "ignore-file": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ignore-file/-/ignore-file-1.1.2.tgz?dl=https://registry.npmjs.org/ignore-file/-/ignore-file-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ignore-file/-/ignore-file-1.1.2.tgz",
       "integrity": "sha1-mlsgSGqg2oP5MXkWqGASui+OkDw=",
       "requires": {
         "minimatch": "^1.0.0"
@@ -2834,7 +2660,7 @@
       "dependencies": {
         "minimatch": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/minimatch/-/minimatch-1.0.0.tgz?dl=https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
           "requires": {
             "lru-cache": "2",
@@ -2845,13 +2671,13 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/imurmurhash/-/imurmurhash-0.1.4.tgz?dl=https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indent-string": {
       "version": "1.2.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/indent-string/-/indent-string-1.2.2.tgz?dl=https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
       "integrity": "sha1-25m8xYPrarux5I3LsZmamGBBy2s=",
       "requires": {
         "get-stdin": "^4.0.1",
@@ -2861,14 +2687,14 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/minimist/-/minimist-1.2.0.tgz?dl=https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/inflight/-/inflight-1.0.6.tgz?dl=https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
@@ -2877,18 +2703,18 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/inherits/-/inherits-2.0.3.tgz?dl=https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ini/-/ini-1.3.5.tgz?dl=https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "3.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/inquirer/-/inquirer-3.3.0.tgz?dl=https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -2909,14 +2735,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-regex/-/ansi-regex-3.0.0.tgz?dl=https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-styles/-/ansi-styles-3.2.1.tgz?dl=https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -2924,8 +2750,8 @@
         },
         "chalk": {
           "version": "2.4.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/chalk/-/chalk-2.4.1.tgz?dl=https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -2935,20 +2761,20 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz?dl=https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash/-/lodash-4.17.10.tgz?dl=https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string-width/-/string-width-2.1.1.tgz?dl=https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -2957,7 +2783,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-ansi/-/strip-ansi-4.0.0.tgz?dl=https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -2966,8 +2792,8 @@
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -2977,8 +2803,8 @@
     },
     "invariant": {
       "version": "2.2.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/invariant/-/invariant-2.2.4.tgz?dl=https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
@@ -2986,12 +2812,12 @@
     },
     "invert-kv": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/invert-kv/-/invert-kv-1.0.0.tgz?dl=https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ioredis": {
       "version": "1.15.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ioredis/-/ioredis-1.15.1.tgz?dl=https://registry.npmjs.org/ioredis/-/ioredis-1.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-1.15.1.tgz",
       "integrity": "sha1-UlJVzM1Ve904oO00ZhmfWesLnRw=",
       "requires": {
         "bluebird": "^2.9.34",
@@ -3003,34 +2829,34 @@
     },
     "ip": {
       "version": "0.3.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ip/-/ip-0.3.3.tgz?dl=https://registry.npmjs.org/ip/-/ip-0.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz",
       "integrity": "sha1-jugwnpLwsEDSh/cu+soaIXAtP7Q="
     },
     "ipaddr.js": {
       "version": "1.8.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
     },
     "is-arrayish": {
       "version": "0.3.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM="
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "is-callable": {
       "version": "1.1.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-date-object": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-date-object/-/is-date-object-1.0.1.tgz?dl=https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-finite/-/is-finite-1.0.2.tgz?dl=https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
         "number-is-nan": "^1.0.0"
@@ -3038,7 +2864,7 @@
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz?dl=https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
         "number-is-nan": "^1.0.0"
@@ -3046,20 +2872,20 @@
     },
     "is-object": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-object/-/is-object-1.0.1.tgz?dl=https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-path-cwd/-/is-path-cwd-1.0.0.tgz?dl=https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz?dl=https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
         "is-path-inside": "^1.0.0"
@@ -3067,7 +2893,7 @@
     },
     "is-path-inside": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-path-inside/-/is-path-inside-1.0.1.tgz?dl=https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
@@ -3076,13 +2902,13 @@
     },
     "is-promise": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-promise/-/is-promise-2.1.0.tgz?dl=https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-regex/-/is-regex-1.0.4.tgz?dl=https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
@@ -3091,52 +2917,55 @@
     },
     "is-resolvable": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-resolvable/-/is-resolvable-1.1.0.tgz?dl=https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-stream/-/is-stream-1.1.0.tgz?dl=https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true,
       "optional": true
     },
     "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-symbol/-/is-symbol-1.0.1.tgz?dl=https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-typedarray/-/is-typedarray-1.0.0.tgz?dl=https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isarray/-/isarray-1.0.0.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isemail": {
       "version": "2.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isemail/-/isemail-2.2.1.tgz?dl=https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
       "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isexe/-/isexe-2.0.0.tgz?dl=https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isstream/-/isstream-0.1.2.tgz?dl=https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jade": {
       "version": "0.26.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jade/-/jade-0.26.3.tgz?dl=https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
       "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
       "dev": true,
       "requires": {
@@ -3146,13 +2975,13 @@
       "dependencies": {
         "commander": {
           "version": "0.6.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/commander/-/commander-0.6.1.tgz?dl=https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
           "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.3.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mkdirp/-/mkdirp-0.3.0.tgz?dl=https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
           "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
           "dev": true
         }
@@ -3160,53 +2989,39 @@
     },
     "jmespath": {
       "version": "0.15.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jmespath/-/jmespath-0.15.0.tgz?dl=https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "joi": {
       "version": "8.4.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/joi/-/joi-8.4.2.tgz?dl=https://registry.npmjs.org/joi/-/joi-8.4.2.tgz",
+      "resolved": "http://registry.npmjs.org/joi/-/joi-8.4.2.tgz",
       "integrity": "sha1-vXd0ZY/pkFjYmU7R1LmWJITruFk=",
       "requires": {
         "hoek": "4.x.x",
         "isemail": "2.x.x",
         "moment": "2.x.x",
         "topo": "2.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
-        }
       }
     },
     "joi-of-cql": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/joi-of-cql/-/joi-of-cql-1.0.2.tgz?dl=https://registry.npmjs.org/joi-of-cql/-/joi-of-cql-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/joi-of-cql/-/joi-of-cql-1.0.2.tgz",
       "integrity": "sha1-W/3NgEi3q+XwIRcpVWFSZD7PI40=",
       "requires": {
         "joi": "^8.0.4",
         "uuid": "^2.0.1"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-2.0.3.tgz?dl=https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-        }
       }
     },
     "js-tokens": {
       "version": "3.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/js-tokens/-/js-tokens-3.0.2.tgz?dl=https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
       "version": "3.12.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha1-6u1lbsg0TxD1J8a/obbiJE3hZ9E=",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -3215,14 +3030,14 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsbn/-/jsbn-0.1.1.tgz?dl=https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
     "jshint": {
       "version": "2.9.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jshint/-/jshint-2.9.6.tgz",
-      "integrity": "sha1-GbNOV4CVo0ko/gBhNabLcBN7nAg=",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.6.tgz",
+      "integrity": "sha512-KO9SIAKTlJQOM4lE64GQUtGBRpTOuvbrRrSZw3AhUxMNG266nX9hK2cKA4SBhXOj0irJGyNyGSLT62HGOVDEOA==",
       "dev": true,
       "requires": {
         "cli": "~1.0.0",
@@ -3239,14 +3054,14 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
         },
         "strip-json-comments": {
           "version": "1.0.4",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-json-comments/-/strip-json-comments-1.0.4.tgz?dl=https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
           "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
           "dev": true
         }
@@ -3254,39 +3069,39 @@
     },
     "json": {
       "version": "9.0.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/json/-/json-9.0.6.tgz?dl=https://registry.npmjs.org/json/-/json-9.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/json/-/json-9.0.6.tgz",
       "integrity": "sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=",
       "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/json-schema/-/json-schema-0.2.3.tgz?dl=https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz?dl=https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz?dl=https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz?dl=https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json-try-parse": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/json-try-parse/-/json-try-parse-1.0.0.tgz?dl=https://registry.npmjs.org/json-try-parse/-/json-try-parse-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-try-parse/-/json-try-parse-1.0.0.tgz",
       "integrity": "sha1-i7jZAz/et1TOWWNTVWoFXrDmP9o="
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "optional": true,
@@ -3296,12 +3111,12 @@
     },
     "jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonparse/-/jsonparse-1.3.1.tgz?dl=https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsprim/-/jsprim-1.4.1.tgz?dl=https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -3312,7 +3127,7 @@
     },
     "jsx-ast-utils": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz?dl=https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
       "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
       "dev": true,
       "requires": {
@@ -3321,13 +3136,13 @@
     },
     "just-extend": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/just-extend/-/just-extend-3.0.0.tgz",
-      "integrity": "sha1-zuAEAx6qv2QG2gOnuE5P6deO8og=",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
+      "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
       "dev": true
     },
     "jwa": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jwa/-/jwa-1.0.2.tgz?dl=https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
       "integrity": "sha1-/Xlgnx53Limdzo3bdtAGWd2DUR8=",
       "requires": {
         "base64url": "~0.0.4",
@@ -3337,14 +3152,14 @@
       "dependencies": {
         "base64url": {
           "version": "0.0.6",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/base64url/-/base64url-0.0.6.tgz?dl=https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "integrity": "sha1-lZezazMNscQkdzIuqH6oAnSZuCs="
         }
       }
     },
     "jws": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jws/-/jws-3.0.0.tgz?dl=https://registry.npmjs.org/jws/-/jws-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.0.0.tgz",
       "integrity": "sha1-2l8meJfdTpz4E3l52zP8VKPAVBg=",
       "requires": {
         "base64url": "~1.0.4",
@@ -3353,19 +3168,19 @@
     },
     "kew": {
       "version": "0.7.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/kew/-/kew-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "dev": true,
       "optional": true
     },
     "killer": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/killer/-/killer-0.1.0.tgz?dl=https://registry.npmjs.org/killer/-/killer-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/killer/-/killer-0.1.0.tgz",
       "integrity": "sha1-l6Lz9PqRc7qRvSFzI2pdXyiI9go="
     },
     "klaw": {
       "version": "1.3.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/klaw/-/klaw-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "optional": true,
@@ -3375,15 +3190,15 @@
     },
     "kuler": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/kuler/-/kuler-1.0.0.tgz",
-      "integrity": "sha1-kErTHDc7eBaVhU0yvjOBi/HWAlA=",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.0.tgz",
+      "integrity": "sha512-oyy6pu/yWRjiVfCoJebNUKFL061sNtrs9ejKTbirIwY3oiHmENVCSkHhxDV85Dkm7JYR/czMCBeoM87WilTdSg==",
       "requires": {
         "colornames": "^1.1.1"
       }
     },
     "lcid": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lcid/-/lcid-1.0.0.tgz?dl=https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
         "invert-kv": "^1.0.0"
@@ -3391,7 +3206,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/levn/-/levn-0.3.0.tgz?dl=https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -3401,7 +3216,7 @@
     },
     "list-stream": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/list-stream/-/list-stream-1.0.1.tgz?dl=https://registry.npmjs.org/list-stream/-/list-stream-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/list-stream/-/list-stream-1.0.1.tgz",
       "integrity": "sha1-40SSrdzNGhZbAorW15WjbE/ZXSk=",
       "requires": {
         "readable-stream": "~2.0.5",
@@ -3410,7 +3225,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-2.0.6.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3420,32 +3235,27 @@
             "string_decoder": "~0.10.x",
             "util-deprecate": "~1.0.1"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-0.10.31.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "lodash": {
       "version": "3.10.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash/-/lodash-3.10.1.tgz?dl=https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz?dl=https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
       "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
     },
     "lodash._arrayeach": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz?dl=https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
       "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz?dl=https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
     },
     "lodash._basedifference": {
@@ -3469,7 +3279,7 @@
     },
     "lodash._basefor": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._basefor/-/lodash._basefor-3.0.3.tgz?dl=https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
       "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
     },
     "lodash._baseindexof": {
@@ -3479,7 +3289,7 @@
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz?dl=https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
       "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
     },
     "lodash._cacheindexof": {
@@ -3489,7 +3299,7 @@
     },
     "lodash._createassigner": {
       "version": "3.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz?dl=https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
       "requires": {
         "lodash._bindcallback": "^3.0.0",
@@ -3507,17 +3317,17 @@
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._getnative/-/lodash._getnative-3.9.1.tgz?dl=https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz?dl=https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
     },
     "lodash.assign": {
       "version": "4.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.assign/-/lodash.assign-4.2.0.tgz?dl=https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
@@ -3533,34 +3343,34 @@
     },
     "lodash.flatten": {
       "version": "4.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.flatten/-/lodash.flatten-4.4.0.tgz?dl=https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.get/-/lodash.get-4.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz?dl=https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.isarray/-/lodash.isarray-3.0.4.tgz?dl=https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
     "lodash.isempty": {
       "version": "4.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.isempty/-/lodash.isempty-4.4.0.tgz?dl=https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
       "dev": true
     },
     "lodash.isplainobject": {
       "version": "3.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz?dl=https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
       "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
       "requires": {
         "lodash._basefor": "^3.0.0",
@@ -3570,12 +3380,12 @@
     },
     "lodash.istypedarray": {
       "version": "3.0.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz?dl=https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
       "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.keys/-/lodash.keys-3.1.2.tgz?dl=https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "requires": {
         "lodash._getnative": "^3.0.0",
@@ -3585,7 +3395,7 @@
     },
     "lodash.keysin": {
       "version": "3.0.8",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.keysin/-/lodash.keysin-3.0.8.tgz?dl=https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
       "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
       "requires": {
         "lodash.isarguments": "^3.0.0",
@@ -3594,7 +3404,7 @@
     },
     "lodash.merge": {
       "version": "3.3.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.merge/-/lodash.merge-3.3.2.tgz?dl=https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
       "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
       "requires": {
         "lodash._arraycopy": "^3.0.0",
@@ -3612,23 +3422,23 @@
     },
     "lodash.pick": {
       "version": "4.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.pick/-/lodash.pick-4.4.0.tgz?dl=https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.pickby": {
       "version": "4.6.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.pickby/-/lodash.pickby-4.6.0.tgz?dl=https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
       "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
       "dev": true
     },
     "lodash.restparam": {
       "version": "3.6.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.restparam/-/lodash.restparam-3.6.1.tgz?dl=https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
     },
     "lodash.toplainobject": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz?dl=https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
       "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
       "requires": {
         "lodash._basecopy": "^3.0.0",
@@ -3636,20 +3446,20 @@
       }
     },
     "lolex": {
-      "version": "2.7.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lolex/-/lolex-2.7.1.tgz",
-      "integrity": "sha1-5AqMTR8UtTaqA+QqU3x6268MIL4=",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
       "dev": true
     },
     "long": {
       "version": "2.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/long/-/long-2.4.0.tgz?dl=https://registry.npmjs.org/long/-/long-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/long/-/long-2.4.0.tgz",
       "integrity": "sha1-n6GAux2VAM3CnEFWdmoZleH0Uk8="
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -3657,22 +3467,22 @@
     },
     "lru-cache": {
       "version": "2.7.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lru-cache/-/lru-cache-2.7.3.tgz?dl=https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
     "map-obj": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/map-obj/-/map-obj-1.0.1.tgz?dl=https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/media-typer/-/media-typer-0.3.0.tgz?dl=https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "meow": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/meow/-/meow-2.0.0.tgz?dl=https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
       "integrity": "sha1-j1MKjs9dQNP0tN+Tw0cpAPuiqPE=",
       "requires": {
         "camelcase-keys": "^1.0.0",
@@ -3683,24 +3493,29 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/minimist/-/minimist-1.2.0.tgz?dl=https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "object-assign": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
+          "integrity": "sha1-5l3Idm07R7S4MHRlyDEdoDCwcKY="
         }
       }
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/merge-descriptors/-/merge-descriptors-1.0.1.tgz?dl=https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/methods/-/methods-1.1.2.tgz?dl=https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "millisecond": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/millisecond/-/millisecond-0.1.2.tgz?dl=https://registry.npmjs.org/millisecond/-/millisecond-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/millisecond/-/millisecond-0.1.2.tgz",
       "integrity": "sha1-bMWtOGJByrjniv+WT4cCjuyS2sU="
     },
     "mime": {
@@ -3710,39 +3525,39 @@
     },
     "mime-db": {
       "version": "1.36.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mime-db/-/mime-db-1.36.0.tgz",
-      "integrity": "sha1-UCBHjbPH/pOq17vMTc+GnEM2M5c="
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
     },
     "mime-types": {
       "version": "2.1.20",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mime-types/-/mime-types-2.1.20.tgz",
-      "integrity": "sha1-kwy3GdVx6QNzhSD4RwkRVIyizBk=",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
         "mime-db": "~1.36.0"
       }
     },
     "mimic-fn": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mimic-fn/-/mimic-fn-1.2.0.tgz?dl=https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/minimatch/-/minimatch-3.0.4.tgz?dl=https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/minimist/-/minimist-0.0.8.tgz?dl=https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mkdirp/-/mkdirp-0.5.1.tgz?dl=https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -3750,7 +3565,7 @@
     },
     "mocha": {
       "version": "2.5.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mocha/-/mocha-2.5.3.tgz?dl=https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "resolved": "http://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
       "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
       "dev": true,
       "requires": {
@@ -3768,7 +3583,7 @@
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/debug/-/debug-2.2.0.tgz?dl=https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
@@ -3777,13 +3592,13 @@
         },
         "escape-string-regexp": {
           "version": "1.0.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz?dl=https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
           "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
           "dev": true
         },
         "glob": {
           "version": "3.2.11",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/glob/-/glob-3.2.11.tgz?dl=https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
@@ -3793,7 +3608,7 @@
         },
         "minimatch": {
           "version": "0.3.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/minimatch/-/minimatch-0.3.0.tgz?dl=https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
@@ -3803,13 +3618,13 @@
         },
         "ms": {
           "version": "0.7.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ms/-/ms-0.7.1.tgz?dl=https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         },
         "supports-color": {
           "version": "1.2.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/supports-color/-/supports-color-1.2.0.tgz?dl=https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
           "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
           "dev": true
         }
@@ -3817,18 +3632,18 @@
     },
     "module-not-found-error": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/module-not-found-error/-/module-not-found-error-1.0.1.tgz?dl=https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
       "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
       "dev": true
     },
     "moment": {
       "version": "2.22.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/moment/-/moment-2.22.2.tgz",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
       "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "morgan-json": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/morgan-json/-/morgan-json-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/morgan-json/-/morgan-json-1.1.0.tgz",
       "integrity": "sha1-+MQLZ7fX4A5ns7upQhntJ29VD/Q=",
       "requires": {
         "diagnostics": "^1.0.1"
@@ -3836,19 +3651,19 @@
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ms/-/ms-2.0.0.tgz?dl=https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mute-stream/-/mute-stream-0.0.7.tgz?dl=https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
     "nano": {
-      "version": "7.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/nano/-/nano-7.0.0.tgz",
-      "integrity": "sha1-EXeAiQQ+QtzlLSa3CXzKXtIcSlU=",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/nano/-/nano-7.1.0.tgz",
+      "integrity": "sha512-wDmmuUbCnqTykpStLYf46/rn4at6qMNsV7DeMks/jQmhHJUm9q/k4kar7c34CkHnMpLLIoT12+XmKWofTudNCQ==",
       "dev": true,
       "requires": {
         "@types/request": "^2.47.1",
@@ -3857,65 +3672,17 @@
         "errs": "^0.3.2",
         "lodash.isempty": "^4.4.0",
         "request": "^2.85.0"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.88.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/request/-/request-2.88.0.tgz",
-          "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/safe-buffer/-/safe-buffer-5.1.2.tgz?dl=https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
-          "dev": true
-        }
       }
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/natural-compare/-/natural-compare-1.4.0.tgz?dl=https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "nconf": {
       "version": "0.8.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/nconf/-/nconf-0.8.5.tgz?dl=https://registry.npmjs.org/nconf/-/nconf-0.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.8.5.tgz",
       "integrity": "sha1-8pQeFWGVL6kGu7MjKM+I1MY155Q=",
       "requires": {
         "async": "^1.4.0",
@@ -3926,7 +3693,7 @@
     },
     "ndjson": {
       "version": "1.4.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ndjson/-/ndjson-1.4.4.tgz?dl=https://registry.npmjs.org/ndjson/-/ndjson-1.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.4.4.tgz",
       "integrity": "sha1-eCAmc24Uaf7m7qED6IVxM2xyw3E=",
       "requires": {
         "minimist": "^1.2.0",
@@ -3936,32 +3703,23 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/minimist/-/minimist-1.2.0.tgz?dl=https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2/-/through2-2.0.3.tgz?dl=https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
-          }
         }
       }
     },
     "negotiator": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/negotiator/-/negotiator-0.6.1.tgz?dl=https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "nise": {
-      "version": "1.4.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/nise/-/nise-1.4.4.tgz",
-      "integrity": "sha1-uNndNTNMmeUUt15G/MOONYyuzdA=",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.5.tgz",
+      "integrity": "sha512-OHRVvdxKgwZELf2DTgsJEIA4MOq8XWvpSUzoOXyxJ2mY0mMENWC66+70AShLR2z05B1dzrzWlUQJmJERlOUpZw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
+        "@sinonjs/formatio": "3.0.0",
         "just-extend": "^3.0.0",
         "lolex": "^2.3.2",
         "path-to-regexp": "^1.7.0",
@@ -3970,13 +3728,13 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "path-to-regexp": {
           "version": "1.7.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
           "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
           "dev": true,
           "requires": {
@@ -3985,9 +3743,14 @@
         }
       }
     },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    },
     "npm": {
       "version": "2.14.22",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/npm/-/npm-2.14.22.tgz?dl=https://registry.npmjs.org/npm/-/npm-2.14.22.tgz",
+      "resolved": "http://registry.npmjs.org/npm/-/npm-2.14.22.tgz",
       "integrity": "sha1-2sOgPVBRtgpTebEge3xuE32MFpo=",
       "dev": true,
       "requires": {
@@ -4066,42 +3829,37 @@
       "dependencies": {
         "abbrev": {
           "version": "1.0.7",
-          "resolved": false,
-          "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
+          "bundled": true,
           "dev": true
         },
         "ansi": {
           "version": "0.3.1",
-          "resolved": false,
-          "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+          "bundled": true,
           "dev": true
         },
         "ansi-regex": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+          "bundled": true,
           "dev": true
         },
         "ansicolors": {
           "version": "0.3.2",
-          "resolved": false,
+          "bundled": true,
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "resolved": false,
+          "bundled": true,
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "bundled": true,
           "dev": true
         },
         "async-some": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "dezalgo": "^1.0.2"
@@ -4109,8 +3867,7 @@
         },
         "block-stream": {
           "version": "0.0.8",
-          "resolved": false,
-          "integrity": "sha1-Boj0baK7+c/wxPaCJaDLlcvopGs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inherits": "~2.0.0"
@@ -4118,26 +3875,22 @@
         },
         "char-spinner": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-5upnvSR+EHESmDt6sEee02KAAIE=",
+          "bundled": true,
           "dev": true
         },
         "chmodr": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-BGYrky0PAuxm3qorDqQoEZaOPrk=",
+          "bundled": true,
           "dev": true
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+          "bundled": true,
           "dev": true
         },
         "cmd-shim": {
           "version": "2.0.2",
-          "resolved": false,
-          "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -4146,8 +3899,7 @@
         },
         "columnify": {
           "version": "1.5.4",
-          "resolved": false,
-          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "strip-ansi": "^3.0.0",
@@ -4156,8 +3908,7 @@
           "dependencies": {
             "wcwidth": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "defaults": "^1.0.0"
@@ -4165,8 +3916,7 @@
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
-                  "resolved": false,
-                  "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "clone": "^1.0.2"
@@ -4174,8 +3924,7 @@
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "resolved": false,
-                      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -4186,8 +3935,7 @@
         },
         "config-chain": {
           "version": "1.1.10",
-          "resolved": false,
-          "integrity": "sha1-f8OD3g/MhNcRy0Zb0XZXnK1hI0Y=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ini": "^1.3.4",
@@ -4196,16 +3944,14 @@
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
-              "resolved": false,
-              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "dezalgo": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "asap": "^2.0.0",
@@ -4214,22 +3960,19 @@
           "dependencies": {
             "asap": {
               "version": "2.0.3",
-              "resolved": false,
-              "integrity": "sha1-H8HRVk7hFiDfym1nAphQkT+fRnk=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "editor": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
+          "bundled": true,
           "dev": true
         },
         "fs-vacuum": {
           "version": "1.2.7",
-          "resolved": false,
-          "integrity": "sha1-deUB+dKIm6L+n+Evk2ul2tUMo1o=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -4239,8 +3982,7 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.8",
-          "resolved": false,
-          "integrity": "sha1-5Jqt3yiPh9Rv+eiC8hahOrxAd4s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -4251,16 +3993,14 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "resolved": false,
-              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "fstream": {
           "version": "1.0.8",
-          "resolved": false,
-          "integrity": "sha1-fo16c6uzZH7zbkuKFcqAHboD0Dg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -4271,8 +4011,7 @@
         },
         "fstream-npm": {
           "version": "1.0.7",
-          "resolved": false,
-          "integrity": "sha1-ftDRrBPXaG3Z4b9s64vic79tL4Y=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fstream-ignore": "^1.0.0",
@@ -4281,8 +4020,7 @@
           "dependencies": {
             "fstream-ignore": {
               "version": "1.0.3",
-              "resolved": false,
-              "integrity": "sha1-THTZH6iLIrQvT4ahiigg3XnY/N0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "fstream": "^1.0.0",
@@ -4294,20 +4032,17 @@
         },
         "github-url-from-git": {
           "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha1-KF5rUggZABveEoZ0cEN55P8D4N4=",
+          "bundled": true,
           "dev": true
         },
         "github-url-from-username-repo": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
+          "bundled": true,
           "dev": true
         },
         "glob": {
           "version": "5.0.15",
-          "resolved": false,
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inflight": "^1.0.4",
@@ -4319,34 +4054,29 @@
           "dependencies": {
             "path-is-absolute": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.3",
-          "resolved": false,
-          "integrity": "sha1-kgM84RETxB4mKNYf36QLwQ3AFVw=",
+          "bundled": true,
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.1.4",
-          "resolved": false,
-          "integrity": "sha1-2elTsmmIvogJbEbpJklNlgTDAPg=",
+          "bundled": true,
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": false,
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.4",
-          "resolved": false,
-          "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -4355,20 +4085,17 @@
         },
         "inherits": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": false,
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "bundled": true,
           "dev": true
         },
         "init-package-json": {
           "version": "1.9.3",
-          "resolved": false,
-          "integrity": "sha1-yi/5Rwm22aqtZlM8EaCv9kXxXH0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^6.0.0",
@@ -4383,8 +4110,7 @@
           "dependencies": {
             "glob": {
               "version": "6.0.4",
-              "resolved": false,
-              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inflight": "^1.0.4",
@@ -4396,16 +4122,14 @@
               "dependencies": {
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "promzard": {
               "version": "0.3.0",
-              "resolved": false,
-              "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "read": "1"
@@ -4415,14 +4139,12 @@
         },
         "lockfile": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-nTU+z+P1TRULtX+J1RdGk1o5xPU=",
+          "bundled": true,
           "dev": true
         },
         "lru-cache": {
           "version": "3.2.0",
-          "resolved": false,
-          "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.1"
@@ -4430,16 +4152,14 @@
           "dependencies": {
             "pseudomap": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-KbTn83u78+PJuRUpgcQPM9VrKyg=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "minimatch": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "^1.0.0"
@@ -4447,8 +4167,7 @@
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha1-2l+3iu9MRMnkrPUlBk+zII66sEU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "balanced-match": "^0.2.0",
@@ -4457,14 +4176,12 @@
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.1",
-                  "resolved": false,
-                  "integrity": "sha1-e8ZYtL7WHu5CStdPdfXD4sTfPMc=",
+                  "bundled": true,
                   "dev": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -4473,8 +4190,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -4482,16 +4198,14 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": false,
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "node-gyp": {
           "version": "3.3.0",
-          "resolved": false,
-          "integrity": "sha1-fMZ2ty0L4x3Jd/s8k1Ocq3re/x4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fstream": "^1.0.0",
@@ -4512,8 +4226,7 @@
           "dependencies": {
             "glob": {
               "version": "4.5.3",
-              "resolved": false,
-              "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inflight": "^1.0.4",
@@ -4524,8 +4237,7 @@
               "dependencies": {
                 "minimatch": {
                   "version": "2.0.10",
-                  "resolved": false,
-                  "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "brace-expansion": "^1.0.0"
@@ -4533,8 +4245,7 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.3",
-                      "resolved": false,
-                      "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "balanced-match": "^0.3.0",
@@ -4543,14 +4254,12 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "resolved": false,
-                          "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
+                          "bundled": true,
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -4561,8 +4270,7 @@
             },
             "minimatch": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lru-cache": "2",
@@ -4571,22 +4279,19 @@
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
-                  "resolved": false,
-                  "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                  "bundled": true,
                   "dev": true
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "path-array": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "array-index": "^1.0.0"
@@ -4594,8 +4299,7 @@
               "dependencies": {
                 "array-index": {
                   "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "debug": "^2.2.0",
@@ -4604,8 +4308,7 @@
                   "dependencies": {
                     "debug": {
                       "version": "2.2.0",
-                      "resolved": false,
-                      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "ms": "0.7.1"
@@ -4613,16 +4316,14 @@
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "resolved": false,
-                          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "es6-symbol": {
                       "version": "3.0.2",
-                      "resolved": false,
-                      "integrity": "sha1-HpKIeMb15jVBYltLtN9K8H0VQhk=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "d": "~0.1.1",
@@ -4631,8 +4332,7 @@
                       "dependencies": {
                         "d": {
                           "version": "0.1.1",
-                          "resolved": false,
-                          "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "es5-ext": "~0.10.2"
@@ -4640,8 +4340,7 @@
                         },
                         "es5-ext": {
                           "version": "0.10.11",
-                          "resolved": false,
-                          "integrity": "sha1-gYTD5wWoIJSMLb4EOEk3mx29DEU=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "es6-iterator": "2",
@@ -4650,8 +4349,7 @@
                           "dependencies": {
                             "es6-iterator": {
                               "version": "2.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "d": "^0.1.1",
@@ -4671,8 +4369,7 @@
         },
         "nopt": {
           "version": "3.0.6",
-          "resolved": false,
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "abbrev": "1"
@@ -4680,14 +4377,12 @@
         },
         "normalize-git-url": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-1A1BnQWhWHAnHlBTTbt7jM2bClw=",
+          "bundled": true,
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.3.5",
-          "resolved": false,
-          "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -4698,8 +4393,7 @@
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "builtin-modules": "^1.0.0"
@@ -4707,8 +4401,7 @@
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.0",
-                  "resolved": false,
-                  "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -4717,14 +4410,12 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
+          "bundled": true,
           "dev": true
         },
         "npm-install-checks": {
           "version": "1.0.7",
-          "resolved": false,
-          "integrity": "sha1-bZGu2grJaAHx7Xqt7hFqbAoIalc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "npmlog": "0.1 || 1 || 2",
@@ -4733,8 +4424,7 @@
         },
         "npm-package-arg": {
           "version": "4.1.0",
-          "resolved": false,
-          "integrity": "sha1-LgFfisAHN8uX+ZfJy/BZ9Cp0Un0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -4743,8 +4433,7 @@
         },
         "npm-registry-client": {
           "version": "7.0.9",
-          "resolved": false,
-          "integrity": "sha1-G6+G7lKFxObTjUVWII3tVgSSMbs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "chownr": "^1.0.1",
@@ -4764,8 +4453,7 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.5.1",
-              "resolved": false,
-              "integrity": "sha1-87gKz54fSOOHXAaItBtsMWAu6hw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inherits": "~2.0.1",
@@ -4775,8 +4463,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.4",
-                  "resolved": false,
-                  "integrity": "sha1-JSPvJ/+jOde6nahgPy0FmdBu29g=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -4789,62 +4476,53 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "resolved": false,
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "bundled": true,
                       "dev": true
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "resolved": false,
-                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                      "bundled": true,
                       "dev": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "resolved": false,
-                      "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU=",
+                      "bundled": true,
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "resolved": false,
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "resolved": false,
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "resolved": false,
-                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "retry": {
               "version": "0.8.0",
-              "resolved": false,
-              "integrity": "sha1-I2dijcDtskex6rZJ3FOshiisLV8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "npm-user-validate": {
           "version": "0.1.2",
-          "resolved": false,
-          "integrity": "sha1-1YXaC0fJ9BqebKaEtv2EukHr6H0=",
+          "bundled": true,
           "dev": true
         },
         "npmlog": {
           "version": "2.0.2",
-          "resolved": false,
-          "integrity": "sha1-0EcCOLlpe3w8TRa96mWgCxKkZKs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi": "~0.3.1",
@@ -4854,8 +4532,7 @@
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.0.6",
-              "resolved": false,
-              "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "delegates": "^1.0.0",
@@ -4864,16 +4541,14 @@
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "gauge": {
               "version": "1.2.5",
-              "resolved": false,
-              "integrity": "sha1-uA8QfdH308WoX1qnT54BJMqsnac=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi": "^0.3.0",
@@ -4885,20 +4560,17 @@
               "dependencies": {
                 "has-unicode": {
                   "version": "2.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-o82Wwwe6QdVZxaLuQIwSoRxMLsM=",
+                  "bundled": true,
                   "dev": true
                 },
                 "lodash._basetostring": {
                   "version": "3.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                  "bundled": true,
                   "dev": true
                 },
                 "lodash._createpadding": {
                   "version": "3.6.1",
-                  "resolved": false,
-                  "integrity": "sha1-SQe0OFla3FTuiTVSemxCTALIGoc=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lodash.repeat": "^3.0.0"
@@ -4906,8 +4578,7 @@
                 },
                 "lodash.pad": {
                   "version": "3.2.2",
-                  "resolved": false,
-                  "integrity": "sha1-+3/d7Tbrdz+Dmra1KR2sA8tlyIo=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lodash.repeat": "^3.0.0"
@@ -4915,8 +4586,7 @@
                 },
                 "lodash.padleft": {
                   "version": "3.1.1",
-                  "resolved": false,
-                  "integrity": "sha1-FQFR8eAkXtuhXVCvLXHx1c/0ZTA=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lodash._basetostring": "^3.0.0",
@@ -4925,8 +4595,7 @@
                 },
                 "lodash.padright": {
                   "version": "3.1.1",
-                  "resolved": false,
-                  "integrity": "sha1-efd3C6qjlzjAQK61Rl6NiPKqzsA=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lodash._basetostring": "^3.0.0",
@@ -4935,8 +4604,7 @@
                 },
                 "lodash.repeat": {
                   "version": "3.2.0",
-                  "resolved": false,
-                  "integrity": "sha1-3JfgNd0xVYA0K0NOigaJlzlf3ns=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lodash._root": "^3.0.0"
@@ -4944,8 +4612,7 @@
                   "dependencies": {
                     "lodash._root": {
                       "version": "3.0.1",
-                      "resolved": false,
-                      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -4956,8 +4623,7 @@
         },
         "once": {
           "version": "1.3.3",
-          "resolved": false,
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -4965,14 +4631,12 @@
         },
         "opener": {
           "version": "1.4.1",
-          "resolved": false,
-          "integrity": "sha1-iXWQrNGu0zEbcDtYvMtNQ/VvKJU=",
+          "bundled": true,
           "dev": true
         },
         "osenv": {
           "version": "0.1.3",
-          "resolved": false,
-          "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -4981,27 +4645,24 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-43B4vGG1hpBjBTiXJX457BJhtwI=",
+              "bundled": true,
               "dev": true
             },
             "os-tmpdir": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "path-is-inside": {
           "version": "1.0.1",
-          "resolved": false,
+          "bundled": true,
           "dev": true
         },
         "read": {
           "version": "1.0.7",
-          "resolved": false,
-          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mute-stream": "~0.0.4"
@@ -5009,16 +4670,14 @@
           "dependencies": {
             "mute-stream": {
               "version": "0.0.5",
-              "resolved": false,
-              "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "read-installed": {
           "version": "4.0.3",
-          "resolved": false,
-          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -5032,14 +4691,12 @@
           "dependencies": {
             "debuglog": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+              "bundled": true,
               "dev": true
             },
             "readdir-scoped-modules": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -5050,16 +4707,14 @@
             },
             "util-extend": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-u3A7eUgCk93Nz7PGqf6iD0g0Fbw=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "read-package-json": {
           "version": "2.0.3",
-          "resolved": false,
-          "integrity": "sha1-+M7BYnBTtU84SzUyJFReYHVUxdI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^6.0.0",
@@ -5070,8 +4725,7 @@
           "dependencies": {
             "glob": {
               "version": "6.0.4",
-              "resolved": false,
-              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inflight": "^1.0.4",
@@ -5083,16 +4737,14 @@
               "dependencies": {
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "json-parse-helpfulerror": {
               "version": "1.0.3",
-              "resolved": false,
-              "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "jju": "^1.1.0"
@@ -5100,8 +4752,7 @@
               "dependencies": {
                 "jju": {
                   "version": "1.2.1",
-                  "resolved": false,
-                  "integrity": "sha1-7fbsINXWaMgMLADOpj+KlCKktSg=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -5110,8 +4761,7 @@
         },
         "readable-stream": {
           "version": "1.1.13",
-          "resolved": false,
-          "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -5122,28 +4772,24 @@
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
+              "bundled": true,
               "dev": true
             },
             "isarray": {
               "version": "0.0.1",
-              "resolved": false,
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "bundled": true,
               "dev": true
             },
             "string_decoder": {
               "version": "0.10.31",
-              "resolved": false,
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "realize-package-specifier": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-/eMukmRI44+ZM02Vt7CNUeOpjZ8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "dezalgo": "^1.0.1",
@@ -5152,8 +4798,7 @@
         },
         "request": {
           "version": "2.69.0",
-          "resolved": false,
-          "integrity": "sha1-z5HS4AB1KxIXFVwAUkGRGZGiNGo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "aws-sign2": "~0.6.0",
@@ -5181,14 +4826,12 @@
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "resolved": false,
-              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+              "bundled": true,
               "dev": true
             },
             "aws4": {
               "version": "1.2.1",
-              "resolved": false,
-              "integrity": "sha1-UrVlmk0yWD1AX2XhEkrENtB/5aw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lru-cache": "^2.6.5"
@@ -5196,16 +4839,14 @@
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
-                  "resolved": false,
-                  "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "bl": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-jGZJDYJbqE1WDeH2IZailVWzoMQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "readable-stream": "~2.0.5"
@@ -5213,8 +4854,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.5",
-                  "resolved": false,
-                  "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -5227,32 +4867,27 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "resolved": false,
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "bundled": true,
                       "dev": true
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "resolved": false,
-                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                      "bundled": true,
                       "dev": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "resolved": false,
-                      "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU=",
+                      "bundled": true,
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "resolved": false,
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "resolved": false,
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -5261,14 +4896,12 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "resolved": false,
-              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+              "bundled": true,
               "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "resolved": false,
-              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "delayed-stream": "~1.0.0"
@@ -5276,28 +4909,24 @@
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "bundled": true,
               "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "resolved": false,
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "bundled": true,
               "dev": true
             },
             "form-data": {
               "version": "1.0.0-rc3",
-              "resolved": false,
-              "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "async": "^1.4.0",
@@ -5307,16 +4936,14 @@
               "dependencies": {
                 "async": {
                   "version": "1.5.2",
-                  "resolved": false,
-                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "har-validator": {
               "version": "2.0.6",
-              "resolved": false,
-              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "chalk": "^1.1.1",
@@ -5327,8 +4954,7 @@
               "dependencies": {
                 "chalk": {
                   "version": "1.1.1",
-                  "resolved": false,
-                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi-styles": "^2.1.0",
@@ -5340,20 +4966,17 @@
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.1.0",
-                      "resolved": false,
-                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI=",
+                      "bundled": true,
                       "dev": true
                     },
                     "escape-string-regexp": {
                       "version": "1.0.4",
-                      "resolved": false,
-                      "integrity": "sha1-uF5nm0b3LQP7voo79yWdU1whti8=",
+                      "bundled": true,
                       "dev": true
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "ansi-regex": "^2.0.0"
@@ -5361,16 +4984,14 @@
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "resolved": false,
-                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "graceful-readlink": ">= 1.0.0"
@@ -5378,16 +4999,14 @@
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "resolved": false,
-                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.12.4",
-                  "resolved": false,
-                  "integrity": "sha1-1O0rwdf4ja+ND3Y7Pj45ppvTeIA=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "generate-function": "^2.0.0",
@@ -5398,14 +5017,12 @@
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "resolved": false,
-                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "is-property": "^1.0.0"
@@ -5413,30 +5030,26 @@
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "resolved": false,
-                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
+                      "bundled": true,
                       "dev": true
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "resolved": false,
-                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "pinkie": "^2.0.0"
@@ -5444,8 +5057,7 @@
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "resolved": false,
-                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -5454,8 +5066,7 @@
             },
             "hawk": {
               "version": "3.1.3",
-              "resolved": false,
-              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "boom": "2.x.x",
@@ -5466,8 +5077,7 @@
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
-                  "resolved": false,
-                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "hoek": "2.x.x"
@@ -5475,8 +5085,7 @@
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "resolved": false,
-                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "boom": "2.x.x"
@@ -5484,14 +5093,12 @@
                 },
                 "hoek": {
                   "version": "2.16.3",
-                  "resolved": false,
-                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                  "bundled": true,
                   "dev": true
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "resolved": false,
-                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "hoek": "2.x.x"
@@ -5501,8 +5108,7 @@
             },
             "http-signature": {
               "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "assert-plus": "^0.2.0",
@@ -5512,14 +5118,12 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "resolved": false,
-                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                  "bundled": true,
                   "dev": true
                 },
                 "jsprim": {
                   "version": "1.2.2",
-                  "resolved": false,
-                  "integrity": "sha1-8gyQaskqvVjjt5rIvHCkiDJRLaE=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "extsprintf": "1.0.2",
@@ -5529,20 +5133,17 @@
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
-                      "resolved": false,
-                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                      "bundled": true,
                       "dev": true
                     },
                     "json-schema": {
                       "version": "0.2.2",
-                      "resolved": false,
-                      "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
+                      "bundled": true,
                       "dev": true
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "resolved": false,
-                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "extsprintf": "1.0.2"
@@ -5552,8 +5153,7 @@
                 },
                 "sshpk": {
                   "version": "1.7.3",
-                  "resolved": false,
-                  "integrity": "sha1-yqjvleMHZdhWaYtwJfnyEatlli8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "asn1": ">=0.2.3 <0.3.0",
@@ -5567,14 +5167,12 @@
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "resolved": false,
-                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                      "bundled": true,
                       "dev": true
                     },
                     "dashdash": {
                       "version": "1.12.2",
-                      "resolved": false,
-                      "integrity": "sha1-HG9wWISY0Ee4zVd3syuoWl4lvjY=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "assert-plus": "^0.2.0"
@@ -5582,8 +5180,7 @@
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "resolved": false,
-                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -5592,8 +5189,7 @@
                     },
                     "jodid25519": {
                       "version": "1.0.2",
-                      "resolved": false,
-                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -5602,15 +5198,13 @@
                     },
                     "jsbn": {
                       "version": "0.1.0",
-                      "resolved": false,
-                      "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "tweetnacl": {
                       "version": "0.13.3",
-                      "resolved": false,
-                      "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -5620,26 +5214,22 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+              "bundled": true,
               "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "resolved": false,
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "bundled": true,
               "dev": true
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "resolved": false,
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "bundled": true,
               "dev": true
             },
             "mime-types": {
               "version": "2.1.9",
-              "resolved": false,
-              "integrity": "sha1-37OWdktf33W+NLH0EEvDaH+2Nfg=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "mime-db": "~1.21.0"
@@ -5647,60 +5237,51 @@
               "dependencies": {
                 "mime-db": {
                   "version": "1.21.0",
-                  "resolved": false,
-                  "integrity": "sha1-m1I54zU89usBWgDYkCYQJ8NtS6w=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.7",
-              "resolved": false,
-              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+              "bundled": true,
               "dev": true
             },
             "oauth-sign": {
               "version": "0.8.1",
-              "resolved": false,
-              "integrity": "sha1-GCQ5vbkTeL90YOdcZOpD5kSN7wY=",
+              "bundled": true,
               "dev": true
             },
             "qs": {
               "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha1-iMaNWQ6O1Wx2x581LBe5gkZqv80=",
+              "bundled": true,
               "dev": true
             },
             "stringstream": {
               "version": "0.0.5",
-              "resolved": false,
-              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+              "bundled": true,
               "dev": true
             },
             "tough-cookie": {
               "version": "2.2.1",
-              "resolved": false,
-              "integrity": "sha1-OwUWt5nnDoFkQ2oURuflh3/aEY4=",
+              "bundled": true,
               "dev": true
             },
             "tunnel-agent": {
               "version": "0.4.2",
-              "resolved": false,
-              "integrity": "sha1-EQTj82rIcSXChycAZ9WC0YEzv+4=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "retry": {
           "version": "0.9.0",
-          "resolved": false,
-          "integrity": "sha1-b2l+UKDk3cjI9/tUeptg3q1DZ40=",
+          "bundled": true,
           "dev": true
         },
         "rimraf": {
           "version": "2.5.2",
-          "resolved": false,
-          "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.0.0"
@@ -5708,8 +5289,7 @@
           "dependencies": {
             "glob": {
               "version": "7.0.0",
-              "resolved": false,
-              "integrity": "sha1-OyCjV//89GuzhK7W+K6aZH/basQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inflight": "^1.0.4",
@@ -5721,8 +5301,7 @@
               "dependencies": {
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -5731,14 +5310,12 @@
         },
         "semver": {
           "version": "5.1.0",
-          "resolved": false,
-          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+          "bundled": true,
           "dev": true
         },
         "sha": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -5747,8 +5324,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.0.2",
-              "resolved": false,
-              "integrity": "sha1-vsgb6ujPRVFovC5bKzH1vPrtmxs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -5761,32 +5337,27 @@
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
+                  "bundled": true,
                   "dev": true
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                  "bundled": true,
                   "dev": true
                 },
                 "process-nextick-args": {
                   "version": "1.0.3",
-                  "resolved": false,
-                  "integrity": "sha1-4nLu2CXV6fTqdNjXOx/jEcO+tjA=",
+                  "bundled": true,
                   "dev": true
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "resolved": false,
-                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                  "bundled": true,
                   "dev": true
                 },
                 "util-deprecate": {
                   "version": "1.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-NVaj0TxMaqeYPX4kJUeBlxmbeIE=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -5795,25 +5366,22 @@
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": false,
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "bundled": true,
           "dev": true
         },
         "sorted-object": {
           "version": "1.0.0",
-          "resolved": false,
+          "bundled": true,
           "dev": true
         },
         "spdx-license-ids": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-tUndD2Pct0Whfi6joHQC4OMy0eI=",
+          "bundled": true,
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -5821,8 +5389,7 @@
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": false,
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "block-stream": "*",
@@ -5832,25 +5399,22 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "resolved": false,
+          "bundled": true,
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": false,
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "bundled": true,
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+          "bundled": true,
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-correct": "~1.0.0",
@@ -5859,8 +5423,7 @@
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "spdx-license-ids": "^1.0.2"
@@ -5868,8 +5431,7 @@
             },
             "spdx-expression-parse": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "spdx-exceptions": "^1.0.4",
@@ -5878,8 +5440,7 @@
               "dependencies": {
                 "spdx-exceptions": {
                   "version": "1.0.4",
-                  "resolved": false,
-                  "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -5888,8 +5449,7 @@
         },
         "validate-npm-package-name": {
           "version": "2.2.2",
-          "resolved": false,
-          "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "builtins": "0.0.7"
@@ -5897,15 +5457,14 @@
           "dependencies": {
             "builtins": {
               "version": "0.0.7",
-              "resolved": false,
+              "bundled": true,
               "dev": true
             }
           }
         },
         "which": {
           "version": "1.2.4",
-          "resolved": false,
-          "integrity": "sha1-FVf5YIBgTlsRs1meufRbUKnv1yI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-absolute": "^0.1.7",
@@ -5914,8 +5473,7 @@
           "dependencies": {
             "is-absolute": {
               "version": "0.1.7",
-              "resolved": false,
-              "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-relative": "^0.1.0"
@@ -5923,30 +5481,26 @@
               "dependencies": {
                 "is-relative": {
                   "version": "0.1.3",
-                  "resolved": false,
-                  "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "isexe": {
               "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha1-8NR5PtL7XEa/3qt2C7uWX0SFpmw=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "wrappy": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+          "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.1.4",
-          "resolved": false,
-          "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -5958,7 +5512,7 @@
     },
     "npm-package-buffer": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/npm-package-buffer/-/npm-package-buffer-2.1.0.tgz?dl=https://registry.npmjs.org/npm-package-buffer/-/npm-package-buffer-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/npm-package-buffer/-/npm-package-buffer-2.1.0.tgz",
       "integrity": "sha1-yotVatWXbQyIdwORVBRfinx/VuQ=",
       "requires": {
         "tar-buffer": "^1.3.0"
@@ -5966,7 +5520,7 @@
     },
     "npm-publish-split-stream": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/npm-publish-split-stream/-/npm-publish-split-stream-1.0.1.tgz?dl=https://registry.npmjs.org/npm-publish-split-stream/-/npm-publish-split-stream-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/npm-publish-split-stream/-/npm-publish-split-stream-1.0.1.tgz",
       "integrity": "sha1-DVh6VSs2vGTuWMRiMd32gsGrZAY=",
       "requires": {
         "JSONStream": "^1.0.6",
@@ -5975,8 +5529,8 @@
     },
     "npm-registry-couchapp": {
       "version": "2.6.13",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/npm-registry-couchapp/-/npm-registry-couchapp-2.6.13.tgz?dl=https://registry.npmjs.org/npm-registry-couchapp/-/npm-registry-couchapp-2.6.13.tgz",
-      "integrity": "sha1-MIVRIHMVyfZi26MbuJvoqY0iSCY=",
+      "resolved": "https://registry.npmjs.org/npm-registry-couchapp/-/npm-registry-couchapp-2.6.13.tgz",
+      "integrity": "sha512-U3B4J3oMQqQVZhl4GE3LOxv+ZlOjtXg/HVUkwiS8HowdJCPTzIjNjM0u3W6sG4SYqiKqW2GbQBylSrsUKxA7IA==",
       "dev": true,
       "requires": {
         "couchapp": "~0.11.0",
@@ -5986,7 +5540,7 @@
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/semver/-/semver-4.3.6.tgz?dl=https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
           "dev": true
         }
@@ -5994,7 +5548,7 @@
     },
     "npm-verify-stream": {
       "version": "1.3.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/npm-verify-stream/-/npm-verify-stream-1.3.1.tgz?dl=https://registry.npmjs.org/npm-verify-stream/-/npm-verify-stream-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/npm-verify-stream/-/npm-verify-stream-1.3.1.tgz",
       "integrity": "sha1-Hh9ylLG1dJllczID+lIj+XfDOMk=",
       "requires": {
         "async": "~1.3.0",
@@ -6007,12 +5561,12 @@
       "dependencies": {
         "async": {
           "version": "1.3.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/async/-/async-1.3.0.tgz?dl=https://registry.npmjs.org/async/-/async-1.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.3.0.tgz",
           "integrity": "sha1-pvFjHopZWmY0ltClWGvRIAfUhx0="
         },
         "concat-stream": {
           "version": "1.5.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/concat-stream/-/concat-stream-1.5.2.tgz?dl=https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
           "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
           "requires": {
             "inherits": "~2.0.1",
@@ -6022,7 +5576,7 @@
         },
         "duplexify": {
           "version": "3.4.6",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/duplexify/-/duplexify-3.4.6.tgz?dl=https://registry.npmjs.org/duplexify/-/duplexify-3.4.6.tgz",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.6.tgz",
           "integrity": "sha1-HlhqEwKMrzHVFEoFmBP5sHH+xVc=",
           "requires": {
             "end-of-stream": "1.0.0",
@@ -6033,7 +5587,7 @@
         },
         "end-of-stream": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/end-of-stream/-/end-of-stream-1.0.0.tgz?dl=https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
           "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
           "requires": {
             "once": "~1.3.0"
@@ -6041,7 +5595,7 @@
         },
         "once": {
           "version": "1.3.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/once/-/once-1.3.3.tgz?dl=https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "requires": {
             "wrappy": "1"
@@ -6049,7 +5603,7 @@
         },
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-2.0.6.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -6059,23 +5613,18 @@
             "string_decoder": "~0.10.x",
             "util-deprecate": "~1.0.1"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-0.10.31.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/number-is-nan/-/number-is-nan-1.0.1.tgz?dl=https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nyc": {
       "version": "11.9.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/nyc/-/nyc-11.9.0.tgz",
-      "integrity": "sha1-QQbono++c2I6H8i27Lerqica4eQ=",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
+      "integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
@@ -6109,8 +5658,7 @@
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "resolved": false,
-          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2",
@@ -6120,26 +5668,22 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+          "bundled": true,
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": false,
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "bundled": true,
           "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
-          "resolved": false,
-          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "default-require-extensions": "^1.0.0"
@@ -6147,62 +5691,52 @@
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "bundled": true,
           "dev": true
         },
         "arr-diff": {
           "version": "4.0.0",
-          "resolved": false,
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "bundled": true,
           "dev": true
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+          "bundled": true,
           "dev": true
         },
         "arr-union": {
           "version": "3.1.0",
-          "resolved": false,
-          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+          "bundled": true,
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "resolved": false,
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "bundled": true,
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "bundled": true,
           "dev": true
         },
         "assign-symbols": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+          "bundled": true,
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "resolved": false,
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "bundled": true,
           "dev": true
         },
         "atob": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
+          "bundled": true,
           "dev": true
         },
         "babel-code-frame": {
           "version": "6.26.0",
-          "resolved": false,
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -6212,8 +5746,7 @@
         },
         "babel-generator": {
           "version": "6.26.1",
-          "resolved": false,
-          "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-messages": "^6.23.0",
@@ -6228,8 +5761,7 @@
         },
         "babel-messages": {
           "version": "6.23.0",
-          "resolved": false,
-          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-runtime": "^6.22.0"
@@ -6237,8 +5769,7 @@
         },
         "babel-runtime": {
           "version": "6.26.0",
-          "resolved": false,
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "core-js": "^2.4.0",
@@ -6247,8 +5778,7 @@
         },
         "babel-template": {
           "version": "6.26.0",
-          "resolved": false,
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-runtime": "^6.26.0",
@@ -6260,8 +5790,7 @@
         },
         "babel-traverse": {
           "version": "6.26.0",
-          "resolved": false,
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-code-frame": "^6.26.0",
@@ -6277,8 +5806,7 @@
         },
         "babel-types": {
           "version": "6.26.0",
-          "resolved": false,
-          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-runtime": "^6.26.0",
@@ -6289,20 +5817,17 @@
         },
         "babylon": {
           "version": "6.18.0",
-          "resolved": false,
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "bundled": true,
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "bundled": true,
           "dev": true
         },
         "base": {
           "version": "0.11.2",
-          "resolved": false,
-          "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cache-base": "^1.0.1",
@@ -6316,8 +5841,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -6325,8 +5849,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -6334,8 +5857,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -6343,8 +5865,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -6354,22 +5875,19 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -6378,8 +5896,7 @@
         },
         "braces": {
           "version": "2.3.2",
-          "resolved": false,
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -6396,8 +5913,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -6407,14 +5923,12 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "bundled": true,
           "dev": true
         },
         "cache-base": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "collection-visit": "^1.0.0",
@@ -6430,16 +5944,14 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "caching-transform": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "md5-hex": "^1.2.0",
@@ -6449,15 +5961,13 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "resolved": false,
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
-          "resolved": false,
-          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6467,8 +5977,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": false,
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -6480,8 +5989,7 @@
         },
         "class-utils": {
           "version": "0.3.6",
-          "resolved": false,
-          "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
@@ -6492,8 +6000,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -6501,16 +6008,14 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "cliui": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6521,8 +6026,7 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "resolved": false,
-              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -6530,14 +6034,12 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "collection-visit": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "map-visit": "^1.0.0",
@@ -6546,44 +6048,37 @@
         },
         "commondir": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+          "bundled": true,
           "dev": true
         },
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": false,
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "bundled": true,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "resolved": false,
-          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+          "bundled": true,
           "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+          "bundled": true,
           "dev": true
         },
         "core-js": {
           "version": "2.5.6",
-          "resolved": false,
-          "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
+          "bundled": true,
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "resolved": false,
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -6592,8 +6087,7 @@
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": false,
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -6601,26 +6095,22 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+          "bundled": true,
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "bundled": true,
           "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "resolved": false,
-          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+          "bundled": true,
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "strip-bom": "^2.0.0"
@@ -6628,8 +6118,7 @@
         },
         "define-property": {
           "version": "2.0.2",
-          "resolved": false,
-          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.2",
@@ -6638,8 +6127,7 @@
           "dependencies": {
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -6647,8 +6135,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -6656,8 +6143,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -6667,22 +6153,19 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "detect-indent": {
           "version": "4.0.0",
-          "resolved": false,
-          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "repeating": "^2.0.0"
@@ -6690,8 +6173,7 @@
         },
         "error-ex": {
           "version": "1.3.1",
-          "resolved": false,
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-arrayish": "^0.2.1"
@@ -6699,20 +6181,17 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": false,
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "bundled": true,
           "dev": true
         },
         "esutils": {
           "version": "2.0.2",
-          "resolved": false,
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "bundled": true,
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": false,
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -6726,8 +6205,7 @@
           "dependencies": {
             "cross-spawn": {
               "version": "5.1.0",
-              "resolved": false,
-              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lru-cache": "^4.0.1",
@@ -6739,8 +6217,7 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "resolved": false,
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debug": "^2.3.3",
@@ -6754,8 +6231,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -6763,8 +6239,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -6774,8 +6249,7 @@
         },
         "extend-shallow": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "assign-symbols": "^1.0.0",
@@ -6784,8 +6258,7 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-plain-object": "^2.0.4"
@@ -6795,8 +6268,7 @@
         },
         "extglob": {
           "version": "2.0.4",
-          "resolved": false,
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
@@ -6811,8 +6283,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -6820,8 +6291,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -6829,8 +6299,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -6838,8 +6307,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -6847,8 +6315,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -6858,16 +6325,14 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": false,
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -6878,8 +6343,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -6889,8 +6353,7 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
@@ -6900,8 +6363,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -6909,14 +6371,12 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+          "bundled": true,
           "dev": true
         },
         "foreground-child": {
           "version": "1.5.6",
-          "resolved": false,
-          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn": "^4",
@@ -6925,8 +6385,7 @@
         },
         "fragment-cache": {
           "version": "0.2.1",
-          "resolved": false,
-          "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "map-cache": "^0.2.2"
@@ -6934,32 +6393,27 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "bundled": true,
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "bundled": true,
           "dev": true
         },
         "get-value": {
           "version": "2.0.6",
-          "resolved": false,
-          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+          "bundled": true,
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": false,
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -6972,20 +6426,17 @@
         },
         "globals": {
           "version": "9.18.0",
-          "resolved": false,
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "bundled": true,
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": false,
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "bundled": true,
           "dev": true
         },
         "handlebars": {
           "version": "4.0.11",
-          "resolved": false,
-          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "async": "^1.4.0",
@@ -6996,8 +6447,7 @@
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "resolved": false,
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "amdefine": ">=0.0.4"
@@ -7007,8 +6457,7 @@
         },
         "has-ansi": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -7016,14 +6465,12 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "bundled": true,
           "dev": true
         },
         "has-value": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "get-value": "^2.0.6",
@@ -7033,16 +6480,14 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "has-values": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -7051,8 +6496,7 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
@@ -7060,8 +6504,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": false,
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
@@ -7071,8 +6514,7 @@
             },
             "kind-of": {
               "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -7082,20 +6524,17 @@
         },
         "hosted-git-info": {
           "version": "2.6.0",
-          "resolved": false,
-          "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+          "bundled": true,
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": false,
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -7104,14 +6543,12 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
         },
         "invariant": {
           "version": "2.2.4",
-          "resolved": false,
-          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "loose-envify": "^1.0.0"
@@ -7119,14 +6556,12 @@
         },
         "invert-kv": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "bundled": true,
           "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
-          "resolved": false,
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -7134,20 +6569,17 @@
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "resolved": false,
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "bundled": true,
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": false,
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "bundled": true,
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "builtin-modules": "^1.0.0"
@@ -7155,8 +6587,7 @@
         },
         "is-data-descriptor": {
           "version": "0.1.4",
-          "resolved": false,
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -7164,8 +6595,7 @@
         },
         "is-descriptor": {
           "version": "0.1.6",
-          "resolved": false,
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
@@ -7175,22 +6605,19 @@
           "dependencies": {
             "kind-of": {
               "version": "5.1.0",
-              "resolved": false,
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "is-extendable": {
           "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+          "bundled": true,
           "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -7198,14 +6625,12 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "bundled": true,
           "dev": true
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -7213,8 +6638,7 @@
         },
         "is-odd": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-number": "^4.0.0"
@@ -7222,16 +6646,14 @@
           "dependencies": {
             "is-number": {
               "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "is-plain-object": {
           "version": "2.0.4",
-          "resolved": false,
-          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isobject": "^3.0.1"
@@ -7239,58 +6661,49 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "bundled": true,
           "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "resolved": false,
-          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+          "bundled": true,
           "dev": true
         },
         "is-windows": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+          "bundled": true,
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "bundled": true,
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "bundled": true,
           "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
+          "bundled": true,
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "append-transform": "^0.4.0"
@@ -7298,8 +6711,7 @@
         },
         "istanbul-lib-instrument": {
           "version": "1.10.1",
-          "resolved": false,
-          "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-generator": "^6.18.0",
@@ -7313,8 +6725,7 @@
         },
         "istanbul-lib-report": {
           "version": "1.1.3",
-          "resolved": false,
-          "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "istanbul-lib-coverage": "^1.1.2",
@@ -7325,8 +6736,7 @@
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
-              "resolved": false,
-              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "has-flag": "^1.0.0"
@@ -7336,8 +6746,7 @@
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.3",
-          "resolved": false,
-          "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debug": "^3.1.0",
@@ -7349,8 +6758,7 @@
           "dependencies": {
             "debug": {
               "version": "3.1.0",
-              "resolved": false,
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ms": "2.0.0"
@@ -7360,8 +6768,7 @@
         },
         "istanbul-reports": {
           "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha512-OPzVo1fPZ2H+owr8q/LYKLD+vquv9Pj4F+dj808MdHbuQLD7S4ACRjcX+0Tne5Vxt2lxXvdZaL7v+FOOAV281w==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "handlebars": "^4.0.3"
@@ -7369,20 +6776,17 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "bundled": true,
           "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "bundled": true,
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": false,
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -7390,15 +6794,13 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "resolved": false,
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "invert-kv": "^1.0.0"
@@ -7406,8 +6808,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -7419,8 +6820,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -7429,28 +6829,24 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "lodash": {
           "version": "4.17.10",
-          "resolved": false,
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "bundled": true,
           "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+          "bundled": true,
           "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
-          "resolved": false,
-          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "js-tokens": "^3.0.0"
@@ -7458,8 +6854,7 @@
         },
         "lru-cache": {
           "version": "4.1.3",
-          "resolved": false,
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -7468,14 +6863,12 @@
         },
         "map-cache": {
           "version": "0.2.2",
-          "resolved": false,
-          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+          "bundled": true,
           "dev": true
         },
         "map-visit": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-visit": "^1.0.0"
@@ -7483,8 +6876,7 @@
         },
         "md5-hex": {
           "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "md5-o-matic": "^0.1.1"
@@ -7492,14 +6884,12 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+          "bundled": true,
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -7507,8 +6897,7 @@
         },
         "merge-source-map": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "source-map": "^0.6.1"
@@ -7516,16 +6905,14 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "resolved": false,
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "micromatch": {
           "version": "3.1.10",
-          "resolved": false,
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -7545,22 +6932,19 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "bundled": true,
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -7568,14 +6952,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "mixin-deep": {
           "version": "1.3.1",
-          "resolved": false,
-          "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "for-in": "^1.0.2",
@@ -7584,8 +6966,7 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-plain-object": "^2.0.4"
@@ -7595,8 +6976,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -7604,14 +6984,12 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "dev": true
         },
         "nanomatch": {
           "version": "1.2.9",
-          "resolved": false,
-          "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -7630,28 +7008,24 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+              "bundled": true,
               "dev": true
             },
             "array-unique": {
               "version": "0.3.2",
-              "resolved": false,
-              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+              "bundled": true,
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "resolved": false,
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -7662,8 +7036,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": false,
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -7671,20 +7044,17 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true
         },
         "object-copy": {
           "version": "0.1.0",
-          "resolved": false,
-          "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "copy-descriptor": "^0.1.0",
@@ -7694,8 +7064,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -7705,8 +7074,7 @@
         },
         "object-visit": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isobject": "^3.0.0"
@@ -7714,16 +7082,14 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "object.pick": {
           "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isobject": "^3.0.1"
@@ -7731,16 +7097,14 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -7748,8 +7112,7 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "resolved": false,
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "~0.0.1",
@@ -7758,14 +7121,12 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "execa": "^0.7.0",
@@ -7775,14 +7136,12 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+          "bundled": true,
           "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -7790,8 +7149,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -7799,14 +7157,12 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "bundled": true,
           "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
-          "resolved": false,
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "error-ex": "^1.2.0"
@@ -7814,14 +7170,12 @@
         },
         "pascalcase": {
           "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+          "bundled": true,
           "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
@@ -7829,26 +7183,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "bundled": true,
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "resolved": false,
-          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+          "bundled": true,
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -7858,20 +7208,17 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": false,
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "bundled": true,
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "resolved": false,
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "bundled": true,
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pinkie": "^2.0.0"
@@ -7879,8 +7226,7 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "find-up": "^1.0.0"
@@ -7888,8 +7234,7 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "resolved": false,
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
@@ -7900,20 +7245,17 @@
         },
         "posix-character-classes": {
           "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+          "bundled": true,
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+          "bundled": true,
           "dev": true
         },
         "read-pkg": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "load-json-file": "^1.0.0",
@@ -7923,8 +7265,7 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "find-up": "^1.0.0",
@@ -7933,8 +7274,7 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "resolved": false,
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
@@ -7945,14 +7285,12 @@
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "resolved": false,
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "bundled": true,
           "dev": true
         },
         "regex-not": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "extend-shallow": "^3.0.2",
@@ -7961,20 +7299,17 @@
         },
         "repeat-element": {
           "version": "1.1.2",
-          "resolved": false,
-          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+          "bundled": true,
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "resolved": false,
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+          "bundled": true,
           "dev": true
         },
         "repeating": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-finite": "^1.0.0"
@@ -7982,38 +7317,32 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "bundled": true,
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "bundled": true,
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "bundled": true,
           "dev": true
         },
         "resolve-url": {
           "version": "0.2.1",
-          "resolved": false,
-          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+          "bundled": true,
           "dev": true
         },
         "ret": {
           "version": "0.1.15",
-          "resolved": false,
-          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+          "bundled": true,
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "resolved": false,
-          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -8022,8 +7351,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": false,
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.0.5"
@@ -8031,8 +7359,7 @@
         },
         "safe-regex": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ret": "~0.1.10"
@@ -8040,20 +7367,17 @@
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": false,
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "bundled": true,
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true
         },
         "set-value": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -8064,8 +7388,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -8075,8 +7398,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -8084,26 +7406,22 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": false,
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "bundled": true,
           "dev": true
         },
         "snapdragon": {
           "version": "0.8.2",
-          "resolved": false,
-          "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "base": "^0.11.1",
@@ -8118,8 +7436,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -8127,8 +7444,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -8138,8 +7454,7 @@
         },
         "snapdragon-node": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "define-property": "^1.0.0",
@@ -8149,8 +7464,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -8158,8 +7472,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -8167,8 +7480,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -8176,8 +7488,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -8187,22 +7498,19 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "snapdragon-util": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "^3.2.0"
@@ -8210,14 +7518,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": false,
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "bundled": true,
           "dev": true
         },
         "source-map-resolve": {
           "version": "0.5.1",
-          "resolved": false,
-          "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "atob": "^2.0.0",
@@ -8229,14 +7535,12 @@
         },
         "source-map-url": {
           "version": "0.4.0",
-          "resolved": false,
-          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+          "bundled": true,
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "resolved": false,
-          "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "foreground-child": "^1.5.6",
@@ -8249,8 +7553,7 @@
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -8259,14 +7562,12 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+          "bundled": true,
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -8275,14 +7576,12 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+          "bundled": true,
           "dev": true
         },
         "split-string": {
           "version": "3.1.0",
-          "resolved": false,
-          "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "extend-shallow": "^3.0.0"
@@ -8290,8 +7589,7 @@
         },
         "static-extend": {
           "version": "0.1.2",
-          "resolved": false,
-          "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "define-property": "^0.2.5",
@@ -8300,8 +7598,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -8311,8 +7608,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -8321,14 +7617,12 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "bundled": true,
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -8338,8 +7632,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -8347,8 +7640,7 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-utf8": "^0.2.0"
@@ -8356,20 +7648,17 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+          "bundled": true,
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "bundled": true,
           "dev": true
         },
         "test-exclude": {
           "version": "4.2.1",
-          "resolved": false,
-          "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arrify": "^1.0.1",
@@ -8381,20 +7670,17 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+              "bundled": true,
               "dev": true
             },
             "array-unique": {
               "version": "0.3.2",
-              "resolved": false,
-              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+              "bundled": true,
               "dev": true
             },
             "braces": {
               "version": "2.3.2",
-              "resolved": false,
-              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "arr-flatten": "^1.1.0",
@@ -8411,8 +7697,7 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -8422,8 +7707,7 @@
             },
             "expand-brackets": {
               "version": "2.1.4",
-              "resolved": false,
-              "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "debug": "^2.3.3",
@@ -8437,8 +7721,7 @@
               "dependencies": {
                 "define-property": {
                   "version": "0.2.5",
-                  "resolved": false,
-                  "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-descriptor": "^0.1.0"
@@ -8446,8 +7729,7 @@
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -8455,8 +7737,7 @@
                 },
                 "is-accessor-descriptor": {
                   "version": "0.1.6",
-                  "resolved": false,
-                  "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "kind-of": "^3.0.2"
@@ -8464,8 +7745,7 @@
                   "dependencies": {
                     "kind-of": {
                       "version": "3.2.2",
-                      "resolved": false,
-                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "is-buffer": "^1.1.5"
@@ -8475,8 +7755,7 @@
                 },
                 "is-data-descriptor": {
                   "version": "0.1.4",
-                  "resolved": false,
-                  "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "kind-of": "^3.0.2"
@@ -8484,8 +7763,7 @@
                   "dependencies": {
                     "kind-of": {
                       "version": "3.2.2",
-                      "resolved": false,
-                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "is-buffer": "^1.1.5"
@@ -8495,8 +7773,7 @@
                 },
                 "is-descriptor": {
                   "version": "0.1.6",
-                  "resolved": false,
-                  "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-accessor-descriptor": "^0.1.6",
@@ -8506,16 +7783,14 @@
                 },
                 "kind-of": {
                   "version": "5.1.0",
-                  "resolved": false,
-                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "extglob": {
               "version": "2.0.4",
-              "resolved": false,
-              "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "array-unique": "^0.3.2",
@@ -8530,8 +7805,7 @@
               "dependencies": {
                 "define-property": {
                   "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-descriptor": "^1.0.0"
@@ -8539,8 +7813,7 @@
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -8550,8 +7823,7 @@
             },
             "fill-range": {
               "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "extend-shallow": "^2.0.1",
@@ -8562,8 +7834,7 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -8573,8 +7844,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -8582,8 +7852,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -8591,8 +7860,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -8602,8 +7870,7 @@
             },
             "is-number": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
@@ -8611,8 +7878,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": false,
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
@@ -8622,20 +7888,17 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "bundled": true,
               "dev": true
             },
             "micromatch": {
               "version": "3.1.10",
-              "resolved": false,
-              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "arr-diff": "^4.0.0",
@@ -8657,14 +7920,12 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "bundled": true,
           "dev": true
         },
         "to-object-path": {
           "version": "0.3.0",
-          "resolved": false,
-          "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -8672,8 +7933,7 @@
         },
         "to-regex": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "define-property": "^2.0.2",
@@ -8684,8 +7944,7 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -8694,8 +7953,7 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
@@ -8705,14 +7963,12 @@
         },
         "trim-right": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+          "bundled": true,
           "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
-          "resolved": false,
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -8723,8 +7979,7 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "resolved": false,
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -8738,15 +7993,13 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "union-value": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
@@ -8757,8 +8010,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -8766,8 +8018,7 @@
             },
             "set-value": {
               "version": "0.4.3",
-              "resolved": false,
-              "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "extend-shallow": "^2.0.1",
@@ -8780,8 +8031,7 @@
         },
         "unset-value": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "has-value": "^0.3.1",
@@ -8790,8 +8040,7 @@
           "dependencies": {
             "has-value": {
               "version": "0.3.1",
-              "resolved": false,
-              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "get-value": "^2.0.3",
@@ -8801,8 +8050,7 @@
               "dependencies": {
                 "isobject": {
                   "version": "2.1.0",
-                  "resolved": false,
-                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "isarray": "1.0.0"
@@ -8812,28 +8060,24 @@
             },
             "has-values": {
               "version": "0.1.4",
-              "resolved": false,
-              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+              "bundled": true,
               "dev": true
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "urix": {
           "version": "0.1.0",
-          "resolved": false,
-          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+          "bundled": true,
           "dev": true
         },
         "use": {
           "version": "3.1.0",
-          "resolved": false,
-          "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "^6.0.2"
@@ -8841,16 +8085,14 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "validate-npm-package-license": {
           "version": "3.0.3",
-          "resolved": false,
-          "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -8859,8 +8101,7 @@
         },
         "which": {
           "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -8868,27 +8109,23 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "bundled": true,
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "resolved": false,
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": false,
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "bundled": true,
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -8897,8 +8134,7 @@
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -8906,8 +8142,7 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -8919,14 +8154,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "resolved": false,
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -8936,20 +8169,17 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "resolved": false,
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "bundled": true,
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": false,
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "bundled": true,
           "dev": true
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": false,
-          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
@@ -8968,20 +8198,17 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "bundled": true,
               "dev": true
             },
             "camelcase": {
               "version": "4.1.0",
-              "resolved": false,
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "bundled": true,
               "dev": true
             },
             "cliui": {
               "version": "4.1.0",
-              "resolved": false,
-              "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "string-width": "^2.1.1",
@@ -8991,8 +8218,7 @@
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -9000,8 +8226,7 @@
             },
             "yargs-parser": {
               "version": "9.0.2",
-              "resolved": false,
-              "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "camelcase": "^4.1.0"
@@ -9011,8 +8236,7 @@
         },
         "yargs-parser": {
           "version": "8.1.0",
-          "resolved": false,
-          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
@@ -9020,8 +8244,7 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "resolved": false,
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "bundled": true,
               "dev": true
             }
           }
@@ -9030,29 +8253,29 @@
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-assign/-/object-assign-1.0.0.tgz",
-      "integrity": "sha1-5l3Idm07R7S4MHRlyDEdoDCwcKY="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-inspect/-/object-inspect-1.0.2.tgz?dl=https://registry.npmjs.org/object-inspect/-/object-inspect-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.0.2.tgz",
       "integrity": "sha1-qXiFtVPldetACevAm92psc0hl5o=",
       "dev": true
     },
     "object-keys": {
       "version": "1.0.12",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha1-CcU4VTd1dTEMymL1W7M0q/97PtI=",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
       "dev": true
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/on-finished/-/on-finished-2.3.0.tgz?dl=https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "requires": {
         "ee-first": "1.1.1"
@@ -9060,12 +8283,12 @@
     },
     "on-headers": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/on-headers/-/on-headers-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
       "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/once/-/once-1.4.0.tgz?dl=https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
@@ -9073,12 +8296,12 @@
     },
     "one-time": {
       "version": "0.0.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/one-time/-/one-time-0.0.4.tgz?dl=https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
       "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
     },
     "onetime": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/onetime/-/onetime-2.0.1.tgz?dl=https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
@@ -9087,7 +8310,7 @@
     },
     "optimist": {
       "version": "0.3.7",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/optimist/-/optimist-0.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
       "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
       "dev": true,
       "requires": {
@@ -9096,7 +8319,7 @@
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/wordwrap/-/wordwrap-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
@@ -9104,7 +8327,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/optionator/-/optionator-0.8.2.tgz?dl=https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
@@ -9116,9 +8339,14 @@
         "wordwrap": "~1.0.0"
       }
     },
+    "optjs": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
+    },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/os-locale/-/os-locale-1.4.0.tgz?dl=https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -9126,13 +8354,13 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/os-tmpdir/-/os-tmpdir-1.0.2.tgz?dl=https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "parallel-transform": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/parallel-transform/-/parallel-transform-1.0.0.tgz?dl=https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.0.0.tgz",
       "integrity": "sha1-YTDYfhetqxGZk1RJPQ2+6aRBdTw=",
       "requires": {
         "cyclist": "~0.2.2"
@@ -9140,12 +8368,12 @@
     },
     "parseurl": {
       "version": "1.3.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/parseurl/-/parseurl-1.3.2.tgz?dl=https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
     "passport": {
       "version": "0.3.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/passport/-/passport-0.3.2.tgz?dl=https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
+      "resolved": "http://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
       "integrity": "sha1-ndAJ+RXo/glbASSgG4+C2gdRAQI=",
       "requires": {
         "passport-strategy": "1.x.x",
@@ -9154,7 +8382,7 @@
     },
     "passport-http": {
       "version": "0.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/passport-http/-/passport-http-0.3.0.tgz?dl=https://registry.npmjs.org/passport-http/-/passport-http-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/passport-http/-/passport-http-0.3.0.tgz",
       "integrity": "sha1-juU9Q4C+nGDfIVGSUCmCb3cRVgM=",
       "requires": {
         "passport-strategy": "1.x.x"
@@ -9162,7 +8390,7 @@
     },
     "passport-http-bearer": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/passport-http-bearer/-/passport-http-bearer-1.0.1.tgz?dl=https://registry.npmjs.org/passport-http-bearer/-/passport-http-bearer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/passport-http-bearer/-/passport-http-bearer-1.0.1.tgz",
       "integrity": "sha1-FHRp6jZp4qhMYWfvmdu3fh8AmKg=",
       "requires": {
         "passport-strategy": "1.x.x"
@@ -9170,7 +8398,7 @@
     },
     "passport-npm": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/passport-npm/-/passport-npm-2.0.0.tgz?dl=https://registry.npmjs.org/passport-npm/-/passport-npm-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/passport-npm/-/passport-npm-2.0.0.tgz",
       "integrity": "sha1-mLNbcE+y83DTk/m/CBaZXfkerl4=",
       "requires": {
         "body-parser": "~1.15.2",
@@ -9181,7 +8409,7 @@
       "dependencies": {
         "body-parser": {
           "version": "1.15.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/body-parser/-/body-parser-1.15.2.tgz?dl=https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
           "integrity": "sha1-11eM9PHRHV9uqATO813Hp/9trmc=",
           "requires": {
             "bytes": "2.4.0",
@@ -9196,9 +8424,14 @@
             "type-is": "~1.6.13"
           }
         },
+        "bytes": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+          "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+        },
         "debug": {
           "version": "2.2.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/debug/-/debug-2.2.0.tgz?dl=https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "requires": {
             "ms": "0.7.1"
@@ -9206,7 +8439,7 @@
         },
         "http-errors": {
           "version": "1.5.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/http-errors/-/http-errors-1.5.1.tgz?dl=https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
           "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
           "requires": {
             "inherits": "2.0.3",
@@ -9216,22 +8449,22 @@
         },
         "iconv-lite": {
           "version": "0.4.13",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/iconv-lite/-/iconv-lite-0.4.13.tgz?dl=https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
           "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
         },
         "ms": {
           "version": "0.7.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ms/-/ms-0.7.1.tgz?dl=https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
         },
         "qs": {
           "version": "6.2.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/qs/-/qs-6.2.0.tgz?dl=https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
           "integrity": "sha1-O3hIwDwt7OaalSKw+ujEEm10Xzs="
         },
         "raw-body": {
           "version": "2.1.7",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/raw-body/-/raw-body-2.1.7.tgz?dl=https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
           "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
           "requires": {
             "bytes": "2.4.0",
@@ -9241,59 +8474,59 @@
         },
         "setprototypeof": {
           "version": "1.0.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/setprototypeof/-/setprototypeof-1.0.2.tgz?dl=https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
           "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg="
         }
       }
     },
     "passport-strategy": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/passport-strategy/-/passport-strategy-1.0.0.tgz?dl=https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
       "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/path-is-absolute/-/path-is-absolute-1.0.1.tgz?dl=https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/path-is-inside/-/path-is-inside-1.0.2.tgz?dl=https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/path-to-regexp/-/path-to-regexp-0.1.7.tgz?dl=https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "pathval": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pathval/-/pathval-0.1.1.tgz?dl=https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz",
       "integrity": "sha1-CPkRzcqczllCiA2ngXvAtyO2bYI=",
       "dev": true
     },
     "pause": {
       "version": "0.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pause/-/pause-0.0.1.tgz?dl=https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pend/-/pend-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true,
       "optional": true
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/performance-now/-/performance-now-2.1.0.tgz?dl=https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "phantom": {
       "version": "4.0.12",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/phantom/-/phantom-4.0.12.tgz",
-      "integrity": "sha1-eNGM8/Knb+pJCfYWD8q/J0LX2/A=",
+      "resolved": "https://registry.npmjs.org/phantom/-/phantom-4.0.12.tgz",
+      "integrity": "sha512-Tz82XhtPmwCk1FFPmecy7yRGZG2btpzY2KI9fcoPT7zT9det0CcMyfBFPp1S8DqzsnQnm8ZYEfdy528mwVtksA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -9304,15 +8537,15 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/async/-/async-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
           "dev": true,
           "optional": true
         },
         "winston": {
           "version": "2.4.4",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/winston/-/winston-2.4.4.tgz",
-          "integrity": "sha1-oB5NHQoQPPTq2m/B+IazEQ1xw0s=",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+          "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -9328,7 +8561,7 @@
     },
     "phantomjs-prebuilt": {
       "version": "2.1.16",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "optional": true,
@@ -9346,7 +8579,7 @@
       "dependencies": {
         "progress": {
           "version": "1.1.8",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/progress/-/progress-1.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
           "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
           "dev": true,
           "optional": true
@@ -9355,19 +8588,19 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pify/-/pify-2.3.0.tgz?dl=https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pinkie/-/pinkie-2.0.4.tgz?dl=https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pinkie-promise/-/pinkie-promise-2.0.1.tgz?dl=https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -9376,7 +8609,7 @@
     },
     "pkgcloud-aws": {
       "version": "1.4.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pkgcloud-aws/-/pkgcloud-aws-1.4.1.tgz?dl=https://registry.npmjs.org/pkgcloud-aws/-/pkgcloud-aws-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/pkgcloud-aws/-/pkgcloud-aws-1.4.1.tgz",
       "integrity": "sha1-pzU8mh1n/Lorrv9e1Ar4qYKymKI=",
       "requires": {
         "async": "0.9.x",
@@ -9398,30 +8631,30 @@
       "dependencies": {
         "asn1": {
           "version": "0.1.11",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/asn1/-/asn1-0.1.11.tgz?dl=https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
           "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
           "optional": true
         },
         "assert-plus": {
           "version": "0.1.5",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/assert-plus/-/assert-plus-0.1.5.tgz?dl=https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
           "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
           "optional": true
         },
         "async": {
           "version": "0.9.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/async/-/async-0.9.2.tgz?dl=https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/aws-sign2/-/aws-sign2-0.5.0.tgz?dl=https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
           "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
           "optional": true
         },
         "combined-stream": {
           "version": "0.0.7",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/combined-stream/-/combined-stream-0.0.7.tgz?dl=https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
           "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
           "optional": true,
           "requires": {
@@ -9430,18 +8663,18 @@
         },
         "delayed-stream": {
           "version": "0.0.5",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/delayed-stream/-/delayed-stream-0.0.5.tgz?dl=https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
           "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
           "optional": true
         },
         "forever-agent": {
           "version": "0.5.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/forever-agent/-/forever-agent-0.5.2.tgz?dl=https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
           "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
         },
         "form-data": {
           "version": "0.1.4",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/form-data/-/form-data-0.1.4.tgz?dl=https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
           "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
           "optional": true,
           "requires": {
@@ -9452,7 +8685,7 @@
         },
         "http-signature": {
           "version": "0.10.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/http-signature/-/http-signature-0.10.1.tgz?dl=https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
           "optional": true,
           "requires": {
@@ -9461,30 +8694,41 @@
             "ctype": "0.5.3"
           }
         },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
         "mime": {
           "version": "1.2.11",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mime/-/mime-1.2.11.tgz?dl=https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
           "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
         },
         "mime-types": {
           "version": "1.0.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mime-types/-/mime-types-1.0.2.tgz?dl=https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
           "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4="
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/node-uuid/-/node-uuid-1.4.8.tgz?dl=https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
         },
         "oauth-sign": {
           "version": "0.3.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/oauth-sign/-/oauth-sign-0.3.0.tgz?dl=https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
           "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
           "optional": true
         },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
         "request": {
           "version": "2.40.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/request/-/request-2.40.0.tgz?dl=https://registry.npmjs.org/request/-/request-2.40.0.tgz",
+          "resolved": "http://registry.npmjs.org/request/-/request-2.40.0.tgz",
           "integrity": "sha1-TdZw9pbx5uhC5mtLXoOTAaub62c=",
           "requires": {
             "aws-sign2": "~0.5.0",
@@ -9504,14 +8748,23 @@
           "dependencies": {
             "qs": {
               "version": "1.0.2",
-              "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/qs/-/qs-1.0.2.tgz?dl=https://registry.npmjs.org/qs/-/qs-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz",
               "integrity": "sha1-UKk+K1r2aRwxvOpdrnjubqGQN2g="
             }
           }
         },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
+        },
         "tunnel-agent": {
           "version": "0.4.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tunnel-agent/-/tunnel-agent-0.4.3.tgz?dl=https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
           "optional": true
         }
@@ -9519,25 +8772,25 @@
     },
     "pkginfo": {
       "version": "0.2.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pkginfo/-/pkginfo-0.2.3.tgz?dl=https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
       "integrity": "sha1-cjnEKl72wwuPMoQ52bn/cQQkkPg=",
       "dev": true
     },
     "pluralize": {
       "version": "7.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pluralize/-/pluralize-7.0.0.tgz?dl=https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/prelude-ls/-/prelude-ls-1.1.2.tgz?dl=https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "priam": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/priam/-/priam-2.1.0.tgz?dl=https://registry.npmjs.org/priam/-/priam-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/priam/-/priam-2.1.0.tgz",
       "integrity": "sha1-TyvOCOhxNBrrPO5E06aPctksoAc=",
       "requires": {
         "async": "^1.2.1",
@@ -9553,17 +8806,12 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isarray/-/isarray-0.0.1.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/process-nextick-args/-/process-nextick-args-2.0.0.tgz?dl=https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
         },
         "read-only-stream": {
           "version": "1.1.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/read-only-stream/-/read-only-stream-1.1.1.tgz?dl=https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
           "integrity": "sha1-Xad8eZ7ROI0++IoYRxu1kk+KC6E=",
           "requires": {
             "readable-stream": "^1.0.31",
@@ -9572,7 +8820,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-1.1.14.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -9580,89 +8828,33 @@
             "isarray": "0.0.1",
             "string_decoder": "~0.10.x"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-0.10.31.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2/-/through2-2.0.3.tgz?dl=https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isarray/-/isarray-1.0.0.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-2.3.6.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-              "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-1.1.1.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-2.0.3.tgz?dl=https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
         }
       }
     },
     "process-nextick-args": {
       "version": "1.0.7",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/process-nextick-args/-/process-nextick-args-1.0.7.tgz?dl=https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/progress/-/progress-2.0.0.tgz?dl=https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
     "prop-types": {
       "version": "15.6.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha1-BdXKd7RFPphdYPx/+MhZCUpJcQI=",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
       }
     },
     "protobufjs": {
       "version": "3.8.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/protobufjs/-/protobufjs-3.8.2.tgz?dl=https://registry.npmjs.org/protobufjs/-/protobufjs-3.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-3.8.2.tgz",
       "integrity": "sha1-vIJuNMOvRpfo0K96Zp5NYSrtzRc=",
       "requires": {
         "ascli": "~0.3",
@@ -9671,8 +8863,8 @@
     },
     "proxy-addr": {
       "version": "2.0.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/proxy-addr/-/proxy-addr-2.0.4.tgz",
-      "integrity": "sha1-7PxzO/Iv+Mb0B/onUye5q2fki5M=",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
@@ -9680,7 +8872,7 @@
     },
     "proxyquire": {
       "version": "1.8.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/proxyquire/-/proxyquire-1.8.0.tgz?dl=https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
       "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
       "dev": true,
       "requires": {
@@ -9691,50 +8883,50 @@
     },
     "pruddy-error": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pruddy-error/-/pruddy-error-1.0.2.tgz?dl=https://registry.npmjs.org/pruddy-error/-/pruddy-error-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pruddy-error/-/pruddy-error-1.0.2.tgz",
       "integrity": "sha1-s37Bo4v5EHwM3FvGY9PU6ANUroA=",
       "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pseudomap/-/pseudomap-1.0.2.tgz?dl=https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "psl": {
       "version": "1.1.29",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha1-YPWA02AXC7cip5fMcEQR5tqFDGc="
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
     },
     "punycode": {
       "version": "1.3.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/punycode/-/punycode-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/q/-/q-1.5.1.tgz?dl=https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
       "version": "1.2.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/qs/-/qs-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
       "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g="
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/querystring/-/querystring-0.2.0.tgz?dl=https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "ramda": {
       "version": "0.25.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ramda/-/ramda-0.25.0.tgz?dl=https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-      "integrity": "sha1-j99oIxz/qQvC+UYDkKDLdKKbKak=",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
       "dev": true
     },
     "range-parser": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/range-parser/-/range-parser-1.2.0.tgz?dl=https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
@@ -9746,18 +8938,11 @@
         "http-errors": "1.6.3",
         "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "bytes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-        }
       }
     },
     "read-only-stream": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/read-only-stream/-/read-only-stream-2.0.0.tgz?dl=https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
       "requires": {
         "readable-stream": "^2.0.2"
@@ -9765,8 +8950,8 @@
     },
     "readable-stream": {
       "version": "2.2.11",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-2.2.11.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-      "integrity": "sha1-B5azH412iAB/8Lk6gIjTSqF8D3I=",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+      "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -9777,16 +8962,26 @@
         "util-deprecate": "~1.0.1"
       },
       "dependencies": {
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
         }
       }
     },
     "readable-wrap": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-wrap/-/readable-wrap-1.0.0.tgz?dl=https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
       "integrity": "sha1-O1ohHGMeEjA6VJkcgGwX564ga/8=",
       "requires": {
         "readable-stream": "^1.1.13-1"
@@ -9794,12 +8989,12 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isarray/-/isarray-0.0.1.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-1.1.14.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -9807,34 +9002,29 @@
             "isarray": "0.0.1",
             "string_decoder": "~0.10.x"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-0.10.31.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "reads": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/reads/-/reads-1.0.1.tgz?dl=https://registry.npmjs.org/reads/-/reads-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/reads/-/reads-1.0.1.tgz",
       "integrity": "sha1-I3OpCggzivAHBSpilp937z9Pm08="
     },
     "regenerator-runtime": {
       "version": "0.11.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz?dl=https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regexpp": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/regexpp/-/regexpp-1.1.0.tgz?dl=https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-      "integrity": "sha1-DjUW3Qt5BPQT0tQZPc5GGMOmias=",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
       "dev": true
     },
     "registry-mock": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/registry-mock/-/registry-mock-2.0.0.tgz?dl=https://registry.npmjs.org/registry-mock/-/registry-mock-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/registry-mock/-/registry-mock-2.0.0.tgz",
       "integrity": "sha1-gmqhfdxyJoWJcb/rR76zFO6lAiI=",
       "dev": true,
       "requires": {
@@ -9844,7 +9034,7 @@
     },
     "repeating": {
       "version": "1.1.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/repeating/-/repeating-1.1.3.tgz?dl=https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
       "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
       "requires": {
         "is-finite": "^1.0.0"
@@ -9854,7 +9044,6 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -9881,26 +9070,23 @@
         "qs": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-          "dev": true
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-          "dev": true
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
     "request-progress": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/request-progress/-/request-progress-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "optional": true,
@@ -9938,7 +9124,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/require-uncached/-/require-uncached-1.0.3.tgz?dl=https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -9948,24 +9134,24 @@
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/requires-port/-/requires-port-1.0.0.tgz?dl=https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.1.7",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/resolve/-/resolve-1.1.7.tgz?dl=https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
     "resolve-from": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/resolve-from/-/resolve-from-1.0.1.tgz?dl=https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
     "restore-cursor": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/restore-cursor/-/restore-cursor-2.0.0.tgz?dl=https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
@@ -9975,20 +9161,20 @@
     },
     "retry": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/retry/-/retry-0.6.1.tgz?dl=https://registry.npmjs.org/retry/-/retry-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz",
       "integrity": "sha1-/ckO7ZQ/3hG4k1VLjMY9DombqRg="
     },
     "rimraf": {
       "version": "2.6.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/rimraf/-/rimraf-2.6.2.tgz?dl=https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "^7.0.5"
       }
     },
     "run-async": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/run-async/-/run-async-2.3.0.tgz?dl=https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
@@ -9997,13 +9183,13 @@
     },
     "rx-lite": {
       "version": "4.0.8",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/rx-lite/-/rx-lite-4.0.8.tgz?dl=https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
       "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz?dl=https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
@@ -10011,40 +9197,34 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/safer-buffer/-/safer-buffer-2.1.2.tgz?dl=https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
-    },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
       "version": "1.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/sax/-/sax-1.2.1.tgz?dl=https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "secure-keys": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/secure-keys/-/secure-keys-1.0.0.tgz?dl=https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
       "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
     },
     "semver": {
       "version": "5.5.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha1-ff3YgUvbfKvHvg+x1zTPtmyUBHc="
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "send": {
       "version": "0.16.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/send/-/send-0.16.2.tgz?dl=https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha1-bsyh4PjBVtFBWXVZhI32RzCmu8E=",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -10061,30 +9241,22 @@
         "statuses": "~1.4.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/debug/-/debug-2.6.9.tgz?dl=https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "mime": {
           "version": "1.4.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mime/-/mime-1.4.1.tgz?dl=https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY="
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
         },
         "statuses": {
           "version": "1.4.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/statuses/-/statuses-1.4.0.tgz?dl=https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
     "serve-static": {
       "version": "1.13.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/serve-static/-/serve-static-1.13.2.tgz?dl=https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha1-CV6Ecv1bRiN9tQzkhqQ/S4bGzsE=",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -10094,20 +9266,20 @@
     },
     "setheader": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/setheader/-/setheader-1.0.1.tgz",
-      "integrity": "sha1-ZZyQWxlk2yByTjZf0yvEtmx3Wg4=",
+      "resolved": "https://registry.npmjs.org/setheader/-/setheader-1.0.1.tgz",
+      "integrity": "sha512-iNDik8ipRBZHfpbpdWlhfZxc0JM9Cg4NYo8jqBkjSRLPxvcgnrE9oiF3AhpFvypg2erVyWNS+QhykhQt0G9tpA==",
       "requires": {
         "diagnostics": "1.x.x"
       }
     },
     "setprototypeof": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/setprototypeof/-/setprototypeof-1.1.0.tgz?dl=https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/shebang-command/-/shebang-command-1.2.0.tgz?dl=https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
@@ -10116,62 +9288,62 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/shebang-regex/-/shebang-regex-1.0.0.tgz?dl=https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "shelljs": {
       "version": "0.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/shelljs/-/shelljs-0.3.0.tgz?dl=https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/sigmund/-/sigmund-1.0.1.tgz?dl=https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/signal-exit/-/signal-exit-3.0.2.tgz?dl=https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "simple-swizzle": {
       "version": "0.2.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
         "is-arrayish": "^0.3.1"
       }
     },
     "sinon": {
-      "version": "6.1.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/sinon/-/sinon-6.1.5.tgz",
-      "integrity": "sha1-QUUVAtQ81f+50FH79QeVJADoHQk=",
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.3.4.tgz",
+      "integrity": "sha512-NIaR56Z1mefuRBXYrf4otqBxkWiKveX+fvqs3HzFq2b07HcgpkMgIwmQM/owNjNFAHkx0kJXW+Q0mDthiuslXw==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.0.1",
-        "@sinonjs/formatio": "^2.0.0",
-        "@sinonjs/samsam": "^2.0.0",
+        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/formatio": "^3.0.0",
+        "@sinonjs/samsam": "^2.1.1",
         "diff": "^3.5.0",
         "lodash.get": "^4.4.2",
-        "lolex": "^2.7.1",
-        "nise": "^1.4.2",
-        "supports-color": "^5.4.0",
+        "lolex": "^2.7.4",
+        "nise": "^1.4.5",
+        "supports-color": "^5.5.0",
         "type-detect": "^4.0.8"
       },
       "dependencies": {
         "diff": {
           "version": "3.5.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
           "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -10179,15 +9351,15 @@
         },
         "type-detect": {
           "version": "4.0.8",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/type-detect/-/type-detect-4.0.8.tgz",
-          "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
           "dev": true
         }
       }
     },
     "slay": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/slay/-/slay-1.0.2.tgz?dl=https://registry.npmjs.org/slay/-/slay-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/slay/-/slay-1.0.2.tgz",
       "integrity": "sha1-32uKY7iblqA5qv5SL5ur49aLYuM=",
       "requires": {
         "async": "^1.5.0",
@@ -10202,14 +9374,14 @@
       "dependencies": {
         "lodash.merge": {
           "version": "4.6.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.merge/-/lodash.merge-4.6.1.tgz?dl=https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-          "integrity": "sha1-rcJdnLmbk5HFliTzefu6YNcRHVQ="
+          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+          "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
         }
       }
     },
     "slay-config": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/slay-config/-/slay-config-2.2.0.tgz?dl=https://registry.npmjs.org/slay-config/-/slay-config-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/slay-config/-/slay-config-2.2.0.tgz",
       "integrity": "sha1-a5RBZ/6FKkBX+8E2V8EuGoO/hiA=",
       "requires": {
         "diagnostics": "^1.0.1",
@@ -10219,7 +9391,7 @@
     },
     "slay-log": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/slay-log/-/slay-log-2.3.0.tgz?dl=https://registry.npmjs.org/slay-log/-/slay-log-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/slay-log/-/slay-log-2.3.0.tgz",
       "integrity": "sha1-qUXeq77PVJUWSzLtyq3WymMcjf0=",
       "requires": {
         "diagnostics": "^1.0.1",
@@ -10228,8 +9400,8 @@
     },
     "slice-ansi": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/slice-ansi/-/slice-ansi-1.0.0.tgz?dl=https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0"
@@ -10237,7 +9409,7 @@
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz?dl=https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         }
@@ -10245,17 +9417,25 @@
     },
     "sntp": {
       "version": "0.2.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/sntp/-/sntp-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
       "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
       "optional": true,
       "requires": {
         "hoek": "0.9.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
+          "optional": true
+        }
       }
     },
     "split": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/split/-/split-1.0.1.tgz",
-      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -10264,32 +9444,21 @@
     },
     "split2": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/split2/-/split2-2.2.0.tgz?dl=https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha1-GGsldbz4PoW30YRldWI47k7kJJM=",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "requires": {
         "through2": "^2.0.2"
-      },
-      "dependencies": {
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2/-/through2-2.0.3.tgz?dl=https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/sprintf-js/-/sprintf-js-1.0.3.tgz?dl=https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
       "version": "1.14.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/sshpk/-/sshpk-1.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
         "asn1": "~0.2.3",
@@ -10305,12 +9474,12 @@
     },
     "stack-trace": {
       "version": "0.0.10",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/stack-trace/-/stack-trace-0.0.10.tgz?dl=https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "statuses": {
       "version": "1.5.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/statuses/-/statuses-1.5.0.tgz?dl=https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stealthy-require": {
@@ -10321,20 +9490,20 @@
     },
     "stream-events": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/stream-events/-/stream-events-1.0.4.tgz?dl=https://registry.npmjs.org/stream-events/-/stream-events-1.0.4.tgz",
-      "integrity": "sha1-c7/UAHuPZ3tG7GmfFOniMEwvCp4=",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.4.tgz",
+      "integrity": "sha512-D243NJaYs/xBN2QnoiMDY7IesJFIK7gEhnvAYqJa5JvDdnh2dC4qDBwlCf0ohPpX2QRlA/4gnbnPd3rs3KxVcA==",
       "requires": {
         "stubs": "^3.0.0"
       }
     },
     "stream-shift": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/stream-shift/-/stream-shift-1.0.0.tgz?dl=https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string-width/-/string-width-1.0.2.tgz?dl=https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
         "code-point-at": "^1.0.0",
@@ -10343,16 +9512,13 @@
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-1.0.3.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringify-stream": {
       "version": "1.0.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/stringify-stream/-/stringify-stream-1.0.5.tgz?dl=https://registry.npmjs.org/stringify-stream/-/stringify-stream-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/stringify-stream/-/stringify-stream-1.0.5.tgz",
       "integrity": "sha1-5RQHqP3Eyg4cYvFJhous9c8gQFA=",
       "requires": {
         "readable-stream": "~2.1.0"
@@ -10360,7 +9526,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.1.5",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-2.1.5.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
           "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
           "requires": {
             "buffer-shims": "^1.0.0",
@@ -10371,23 +9537,18 @@
             "string_decoder": "~0.10.x",
             "util-deprecate": "~1.0.1"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-0.10.31.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "stringstream": {
       "version": "0.0.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha1-eIAiWw1K0Q4wkn0Weh1vL9OzOnI=",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
       "optional": true
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-ansi/-/strip-ansi-3.0.1.tgz?dl=https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -10395,25 +9556,25 @@
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-json-comments/-/strip-json-comments-2.0.1.tgz?dl=https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "stubs": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/stubs/-/stubs-3.0.0.tgz?dl=https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
     },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/supports-color/-/supports-color-2.0.0.tgz?dl=https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
     "table": {
       "version": "4.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/table/-/table-4.0.2.tgz?dl=https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
         "ajv": "^5.2.3",
@@ -10426,14 +9587,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-regex/-/ansi-regex-3.0.0.tgz?dl=https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-styles/-/ansi-styles-3.2.1.tgz?dl=https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -10441,8 +9602,8 @@
         },
         "chalk": {
           "version": "2.4.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/chalk/-/chalk-2.4.1.tgz?dl=https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -10452,20 +9613,20 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz?dl=https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash/-/lodash-4.17.10.tgz?dl=https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string-width/-/string-width-2.1.1.tgz?dl=https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -10474,7 +9635,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-ansi/-/strip-ansi-4.0.0.tgz?dl=https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -10483,8 +9644,8 @@
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -10494,7 +9655,7 @@
     },
     "tar": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tar/-/tar-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.1.1.tgz",
       "integrity": "sha1-rAZJ4TX6RUbkMMdphRTh2i6KfMQ=",
       "requires": {
         "block-stream": "*",
@@ -10504,7 +9665,7 @@
     },
     "tar-buffer": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tar-buffer/-/tar-buffer-1.3.0.tgz?dl=https://registry.npmjs.org/tar-buffer/-/tar-buffer-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/tar-buffer/-/tar-buffer-1.3.0.tgz",
       "integrity": "sha1-YS9c7H+LDshIM1hSF1j0DHbe7Ys=",
       "requires": {
         "concat-stream": "~1.5.0",
@@ -10513,7 +9674,7 @@
       "dependencies": {
         "concat-stream": {
           "version": "1.5.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/concat-stream/-/concat-stream-1.5.2.tgz?dl=https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
           "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
           "requires": {
             "inherits": "~2.0.1",
@@ -10523,7 +9684,7 @@
         },
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-2.0.6.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -10533,78 +9694,50 @@
             "string_decoder": "~0.10.x",
             "util-deprecate": "~1.0.1"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-0.10.31.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
     "text-hex": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha1-adycGxdEbueakr9biEu0uRJ1BvU="
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/text-table/-/text-table-0.2.0.tgz?dl=https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "throttleit": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/throttleit/-/throttleit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
       "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true,
       "optional": true
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through/-/through-2.3.8.tgz?dl=https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
-      "version": "0.6.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2/-/through2-0.6.5.tgz?dl=https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isarray/-/isarray-0.0.1.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-1.0.34.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-0.10.31.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "tick-tock": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tick-tock/-/tick-tock-1.0.0.tgz?dl=https://registry.npmjs.org/tick-tock/-/tick-tock-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tick-tock/-/tick-tock-1.0.0.tgz",
       "integrity": "sha1-nE1ZZAZPlVGxj63tNN52rXwbpD4=",
       "requires": {
         "millisecond": "0.1.x"
@@ -10617,7 +9750,7 @@
     },
     "tmp": {
       "version": "0.0.31",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tmp/-/tmp-0.0.31.tgz?dl=https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
       "dev": true,
       "requires": {
@@ -10626,7 +9759,7 @@
     },
     "to-camel-case": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/to-camel-case/-/to-camel-case-1.0.0.tgz?dl=https://registry.npmjs.org/to-camel-case/-/to-camel-case-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-camel-case/-/to-camel-case-1.0.0.tgz",
       "integrity": "sha1-GlYFSy+daWKYzmamCJcyK29CPkY=",
       "requires": {
         "to-space-case": "^1.0.0"
@@ -10634,24 +9767,24 @@
     },
     "to-fast-properties": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/to-fast-properties/-/to-fast-properties-1.0.3.tgz?dl=https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
     "to-iso-string": {
       "version": "0.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/to-iso-string/-/to-iso-string-0.0.2.tgz?dl=https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
       "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
       "dev": true
     },
     "to-no-case": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/to-no-case/-/to-no-case-1.0.2.tgz?dl=https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
       "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo="
     },
     "to-snake-case": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/to-snake-case/-/to-snake-case-1.0.0.tgz?dl=https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
       "integrity": "sha1-znRpE4l5RgGah+Yu366upMYIq4w=",
       "requires": {
         "to-space-case": "^1.0.0"
@@ -10659,7 +9792,7 @@
     },
     "to-space-case": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/to-space-case/-/to-space-case-1.0.0.tgz?dl=https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
       "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
       "requires": {
         "to-no-case": "^1.0.0"
@@ -10667,23 +9800,16 @@
     },
     "topo": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/topo/-/topo-2.0.2.tgz?dl=https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
         "hoek": "4.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
-        }
       }
     },
     "tough-cookie": {
       "version": "2.4.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -10691,14 +9817,14 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tunnel-agent/-/tunnel-agent-0.6.0.tgz?dl=https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -10706,13 +9832,13 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tweetnacl/-/tweetnacl-0.14.5.tgz?dl=https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/type-check/-/type-check-0.3.2.tgz?dl=https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -10721,14 +9847,14 @@
     },
     "type-detect": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/type-detect/-/type-detect-0.1.1.tgz?dl=https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
       "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
       "dev": true
     },
     "type-is": {
       "version": "1.6.16",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/type-is/-/type-is-1.6.16.tgz?dl=https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-      "integrity": "sha1-+JzjQVQcZysl7nrjxz3uOyvlAZQ=",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
@@ -10736,38 +9862,38 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/typedarray/-/typedarray-0.0.6.tgz?dl=https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "ultron": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ultron/-/ultron-1.1.1.tgz?dl=https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha1-n+FTahCmZKZSZqHjzPhf02MCvJw="
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "understudy": {
       "version": "4.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/understudy/-/understudy-4.1.0.tgz?dl=https://registry.npmjs.org/understudy/-/understudy-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/understudy/-/understudy-4.1.0.tgz",
       "integrity": "sha1-ttbpYkzLt/ouUZafW+LHSOlp70o="
     },
     "unicode-5.2.0": {
       "version": "0.7.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/unicode-5.2.0/-/unicode-5.2.0-0.7.5.tgz",
-      "integrity": "sha1-4N8SlDGiipUmPYxID7XpqysJc/A=",
+      "resolved": "https://registry.npmjs.org/unicode-5.2.0/-/unicode-5.2.0-0.7.5.tgz",
+      "integrity": "sha512-KVGLW1Bri30x00yv4HNM8kBxoqFXr0Sbo55735nvrlsx4PYBZol3UtoWgO492fSwmsetzPEZzy73rbU8OGXJcA==",
       "dev": true
     },
     "uniq": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uniq/-/uniq-1.0.1.tgz?dl=https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/unpipe/-/unpipe-1.0.0.tgz?dl=https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "url": {
       "version": "0.10.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/url/-/url-0.10.3.tgz?dl=https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
       "requires": {
         "punycode": "1.3.2",
@@ -10776,7 +9902,7 @@
     },
     "url-equal": {
       "version": "0.1.2-1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/url-equal/-/url-equal-0.1.2-1.tgz",
+      "resolved": "https://registry.npmjs.org/url-equal/-/url-equal-0.1.2-1.tgz",
       "integrity": "sha1-IjeVIL/gfSa1kIAEkIruEuhNBf8=",
       "dev": true,
       "requires": {
@@ -10785,7 +9911,7 @@
       "dependencies": {
         "deep-equal": {
           "version": "1.0.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/deep-equal/-/deep-equal-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
           "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
           "dev": true
         }
@@ -10793,32 +9919,32 @@
     },
     "url-join": {
       "version": "0.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/url-join/-/url-join-0.0.1.tgz?dl=https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
       "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g="
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/util-deprecate/-/util-deprecate-1.0.2.tgz?dl=https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/utils-merge/-/utils-merge-1.0.1.tgz?dl=https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-3.0.1.tgz",
-      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+      "version": "2.0.3",
+      "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/vary/-/vary-1.1.2.tgz?dl=https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/verror/-/verror-1.10.0.tgz?dl=https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -10895,6 +10021,11 @@
             "through2": "~0.6.3"
           }
         },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
         "kuler": {
           "version": "0.0.0",
           "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
@@ -10903,28 +10034,43 @@
             "colornames": "0.0.2"
           }
         },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
         },
         "text-hex": {
           "version": "0.0.0",
           "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
           "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
         }
       }
     },
     "watch": {
       "version": "0.8.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/watch/-/watch-0.8.0.tgz?dl=https://registry.npmjs.org/watch/-/watch-0.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-0.8.0.tgz",
       "integrity": "sha1-G7DupT3v5uYh6cjGPANYAH7L28w=",
       "dev": true
     },
     "which": {
       "version": "1.3.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/which/-/which-1.3.1.tgz",
-      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -10932,12 +10078,12 @@
     },
     "window-size": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/window-size/-/window-size-0.1.4.tgz?dl=https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
       "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
     },
     "winston": {
       "version": "2.3.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/winston/-/winston-2.3.1.tgz?dl=https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
       "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
       "requires": {
         "async": "~1.0.0",
@@ -10950,20 +10096,20 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/async/-/async-1.0.0.tgz?dl=https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
         }
       }
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/wordwrap/-/wordwrap-1.0.0.tgz?dl=https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/wrap-ansi/-/wrap-ansi-2.1.0.tgz?dl=https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -10972,12 +10118,12 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/wrappy/-/wrappy-1.0.2.tgz?dl=https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/write/-/write-0.2.1.tgz?dl=https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
@@ -10986,7 +10132,7 @@
     },
     "xml2js": {
       "version": "0.1.14",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/xml2js/-/xml2js-0.1.14.tgz?dl=https://registry.npmjs.org/xml2js/-/xml2js-0.1.14.tgz",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.1.14.tgz",
       "integrity": "sha1-UnTmf1pkxfkpdM2FE54DMq3GuQw=",
       "requires": {
         "sax": ">=0.1.1"
@@ -10994,38 +10140,38 @@
     },
     "xmlbuilder": {
       "version": "4.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/xmlbuilder/-/xmlbuilder-4.2.1.tgz?dl=https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
       "requires": {
         "lodash": "^4.0.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash/-/lodash-4.17.10.tgz?dl=https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc="
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         }
       }
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/xtend/-/xtend-4.0.1.tgz?dl=https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/y18n/-/y18n-3.2.1.tgz?dl=https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
       "version": "2.1.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/yallist/-/yallist-2.1.2.tgz?dl=https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/yargs/-/yargs-3.32.0.tgz?dl=https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
         "camelcase": "^2.0.1",
@@ -11039,14 +10185,14 @@
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/camelcase/-/camelcase-2.1.1.tgz?dl=https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         }
       }
     },
     "yauzl": {
       "version": "2.4.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/yauzl/-/yauzl-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "optional": true,
@@ -11056,7 +10202,7 @@
     },
     "zipline": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/zipline/-/zipline-1.0.0.tgz?dl=https://registry.npmjs.org/zipline/-/zipline-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/zipline/-/zipline-1.0.0.tgz",
       "integrity": "sha1-9Acs1T3ZEIBqLGSv6ItrcpHAfQU=",
       "requires": {
         "demolish": "1.0.x",
@@ -11065,7 +10211,7 @@
       "dependencies": {
         "eventemitter3": {
           "version": "0.1.6",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/eventemitter3/-/eventemitter3-0.1.6.tgz?dl=https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz",
           "integrity": "sha1-jHrES4e6q1XNUMgo3Dh3jqwFLqU="
         }
       }


### PR DESCRIPTION
Should I also attempt to resolve the security issues raised by `npm audit`?

```
$ npm audit
// lots of output
found 92 vulnerabilities (10 low, 54 moderate, 27 high, 1 critical) in 5385 scanned packages
  run `npm audit fix` to fix 1 of them.
  70 vulnerabilities require semver-major dependency updates.
  21 vulnerabilities require manual review. See the full report for details.
``` 