### PR TITLE
[fix] dereference the swagger spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ npm-error.log
 .node_repl_history
 
 # swagger docs
-lib/swagger.json
+lib/wrhs-spec.json

--- a/.npmignore
+++ b/.npmignore
@@ -40,4 +40,4 @@ npm-error.log
 .node_repl_history
 
 # swagger docs
-!lib/swagger.json
+!lib/wrhs-spec.json

--- a/bin/swagger
+++ b/bin/swagger
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+// TODO: extract into npm package
+const path = require('path');
+const fs = require('fs');
+const swaggerDoc = require('swagger-jsdoc');
+const jsonRefs = require('json-refs');
+
+const source = require('../lib/swagger.js');
+const options = { ...source, swaggerDefinition: source };
+delete options.swaggerDefinition.apis;
+const rawSpec = swaggerDoc(options);
+jsonRefs.resolveRefs(rawSpec)
+  .then(spec => {
+    fs.writeFileSync(path.join(__dirname, '..', 'lib', 'wrhs-spec.json'), JSON.stringify(spec.resolved, null, 2));
+  });
+
+

--- a/lib/npm/publisher.js
+++ b/lib/npm/publisher.js
@@ -88,7 +88,8 @@ Publisher.prototype.setup = function () {
    *       description: The npm publish payload
    *     responses:
    *       $ref: '#/responses/Standard'
-   */  this.router = params(new Router())
+   */
+  this.router = params(new Router())
     .put('/:pkg', this.auth, this.verify.bind(this));
 
   this.request = require('hyperquest');

--- a/lib/npm/routes.js
+++ b/lib/npm/routes.js
@@ -83,6 +83,8 @@ module.exports = function (app) {
    *               $ref: '#/definitions/DistTags'
    *       400:
    *         $ref: '#/responses/Standard400'
+   *       401:
+   *         $ref: '#/responses/Standard401'
    *       403:
    *         $ref: '#/responses/Standard403'
    *       404:
@@ -139,6 +141,8 @@ module.exports = function (app) {
    *         description: Success
    *       400:
    *         $ref: '#/responses/Standard400'
+   *       401:
+   *         $ref: '#/responses/Standard401'
    *       403:
    *         $ref: '#/responses/Standard403'
    *       404:
@@ -165,6 +169,8 @@ module.exports = function (app) {
    *               $ref: '#/definitions/DistTags'
    *       400:
    *         $ref: '#/responses/Standard400'
+   *       401:
+   *         $ref: '#/responses/Standard401'
    *       403:
    *         $ref: '#/responses/Standard403'
    *       404:
@@ -191,6 +197,8 @@ module.exports = function (app) {
    *               $ref: '#/definitions/DistTags'
    *       400:
    *         $ref: '#/responses/Standard400'
+   *       401:
+   *         $ref: '#/responses/Standard401'
    *       403:
    *         $ref: '#/responses/Standard403'
    *       404:
@@ -226,6 +234,8 @@ module.exports = function (app) {
    *         $ref: '#/responses/Standard304'
    *       400:
    *         $ref: '#/responses/Standard400'
+   *       401:
+   *         $ref: '#/responses/Standard401'
    *       403:
    *         $ref: '#/responses/Standard403'
    *       404:

--- a/lib/routes/builds.js
+++ b/lib/routes/builds.js
@@ -69,13 +69,14 @@ module.exports = function (app) {
    *             $ref: '#/definitions/Builds'
    *     400:
    *       $ref: '#/responses/Standard400'
+   *     401:
+   *       $ref: '#/responses/Standard401'
    *     403:
    *       $ref: '#/responses/Standard403'
    *     404:
    *       $ref: '#/responses/Standard404'
    *     500:
    *       $ref: '#/responses/Standard500'
-
    */
 
   /**
@@ -203,6 +204,8 @@ module.exports = function (app) {
    *               $ref: '#/definitions/Meta'
    *       400:
    *         $ref: '#/responses/Standard400'
+   *       401:
+   *         $ref: '#/responses/Standard401'
    *       403:
    *         $ref: '#/responses/Standard403'
    *       404:
@@ -404,6 +407,8 @@ module.exports = function (app) {
    *         description: Success
    *       400:
    *         $ref: '#/responses/Standard400'
+   *       401:
+   *         $ref: '#/responses/Standard401'
    *       403:
    *         $ref: '#/responses/Standard403'
    *       404:

--- a/lib/routes/packages.js
+++ b/lib/routes/packages.js
@@ -37,13 +37,14 @@ module.exports = function (app) {
    *             $ref: '#/definitions/Packages'
    *     400:
    *       $ref: '#/responses/Standard400'
+   *     401:
+   *       $ref: '#/responses/Standard401'
    *     403:
    *       $ref: '#/responses/Standard403'
    *     404:
    *       $ref: '#/responses/Standard404'
    *     500:
    *       $ref: '#/responses/Standard500'
-
    */
 
   /**

--- a/lib/routes/release-line.js
+++ b/lib/routes/release-line.js
@@ -29,6 +29,8 @@ module.exports = function (app) {
    *             $ref: '#/definitions/ReleaseLine'
    *     400:
    *       $ref: '#/responses/Standard400'
+   *     401:
+   *       $ref: '#/responses/Standard401'
    *     403:
    *       $ref: '#/responses/Standard403'
    *     404:

--- a/lib/routes/swagger.js
+++ b/lib/routes/swagger.js
@@ -1,6 +1,6 @@
 'use strict';
 const swaggerUI = require('swagger-ui-express');
-const swaggerDefs = require('../swagger.json');
+const swaggerDefs = require('../wrhs-spec.json');
 
 module.exports = function (app) {
   //
@@ -44,6 +44,16 @@ module.exports = function (app) {
    *     type: string
    *     minimum: 1
    *
+   *   Error:
+   *     application/json:
+   *       schema:
+   *         type: object
+   *         properties:
+   *           code:
+   *             type: string
+   *           message:
+   *             type: string
+   *
    * parameters:
    *   Pkg:
    *     in: path
@@ -67,46 +77,44 @@ module.exports = function (app) {
    *       $ref: '#/definitions/VersionNumber'
    *     description: The package version
    *
-   * content:
-   *   Error:
-   *     application/json:
-   *       schema:
-   *         type: object
-   *         properties:
-   *           code:
-   *             type: string
-   *           message:
-   *             type: string
    * responses:
    *   Standard:
    *     200:
-   *       description: OK
+   *       $ref: '#/responses/Standard200'
    *     400:
    *       $ref: '#/responses/Standard400'
+   *     401:
+   *       $ref: '#/responses/Standard401'
    *     403:
    *       $ref: '#/responses/Standard403'
    *     404:
    *       $ref: '#/responses/Standard404'
    *     500:
    *       $ref: '#/responses/Standard500'
+   *   Standard200:
+   *     description: OK
    *   Standard304:
    *     description: Not Modified
    *   Standard400:
    *     description: Bad Request
    *     content:
-   *       $ref: '#/content/Error'
+   *       $ref: '#/definitions/Error'
+   *   Standard401:
+   *     description: Unauthorized
+   *     content:
+   *       $ref: '#/definitions/Error'
    *   Standard403:
    *     description: Forbidden
    *     content:
-   *       $ref: '#/content/Error'
+   *       $ref: '#/definitions/Error'
    *   Standard404:
    *     description: Not Found
    *     content:
-   *       $ref: '#/content/Error'
+   *       $ref: '#/definitions/Error'
    *   Standard500:
    *     description: Internal Server Error
    *     content:
-   *       $ref: '#/content/Error'
+   *       $ref: '#/definitions/Error'
    *
    */
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1332,6 +1332,12 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+      "dev": true
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -2575,6 +2581,12 @@
       "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU=",
       "dev": true
     },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
+      "dev": true
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -2786,6 +2798,15 @@
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+    },
+    "graphlib": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.7.tgz",
+      "integrity": "sha512-TyI9jIy2J4j0qgPmOOrHTCtpPqJGN/aurBwc6ZT+bRii+di1I+Wv3obRhVrmBEXet+qkMaEX67dXrwsd3QQM6w==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.5"
+      }
     },
     "growl": {
       "version": "1.9.2",
@@ -3944,6 +3965,45 @@
       "integrity": "sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=",
       "dev": true
     },
+    "json-refs": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-3.0.12.tgz",
+      "integrity": "sha512-6RbO1Y3e0Hty/tEpXtQG6jUx7g1G8e39GIOuPugobPC8BX1gZ0OGZQpBn1FLWGkuWF35GRGADvhwdEIFpwIjyA==",
+      "dev": true,
+      "requires": {
+        "commander": "~2.11.0",
+        "graphlib": "^2.1.1",
+        "js-yaml": "^3.10.0",
+        "lodash": "^4.17.4",
+        "native-promise-only": "^0.8.1",
+        "path-loader": "^1.0.5",
+        "slash": "^1.0.0",
+        "uri-js": "^3.0.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        },
+        "uri-js": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+          "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        }
+      }
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -4878,6 +4938,12 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -10032,6 +10098,16 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
+    "path-loader": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.9.tgz",
+      "integrity": "sha512-pD37gArtr+/72Tst9oJoDB9k7gB9A09Efj7yyBi5HDUqaxqULXBWW8Rnw2TfNF+3sN7QZv0ZNdW1Qx2pFGW5Jg==",
+      "dev": true,
+      "requires": {
+        "native-promise-only": "^0.8.1",
+        "superagent": "^3.8.3"
+      }
+    },
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
@@ -10888,6 +10964,12 @@
         }
       }
     },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
     "slay": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/slay/-/slay-1.0.2.tgz",
@@ -11289,6 +11371,71 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
+    },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "supports-color": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "report": "nyc report --reporter=lcov",
     "eslint": "eslint-godaddy -c .eslintrc lib/ test/",
     "sandbox": "npm-registry-echo",
-    "swagger": "swagger-jsdoc -d lib/swagger.js -o lib/swagger.json"
+    "swagger": "./bin/swagger"
   },
   "repository": {
     "type": "git",
@@ -92,6 +92,7 @@
     "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-mocha": "^5.3.0",
     "eslint-plugin-react": "^7.1.0",
+    "json-refs": "^3.0.12",
     "mocha": "^6.0.2",
     "nock": "^10.0.6",
     "npm": "^6.8.0",


### PR DESCRIPTION
This makes warehouse.ai's swagger spec compatible with AWS API Gateway.

Will have a follow up PR once I extract the `./bin/swagger` into an npm package, but getting this out there for now to unblock.