### PR TITLE
Enable output of *.html files when DEBUG=yes. Slightly improved logging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ npm-error.log
 
 # swagger docs
 lib/wrhs-spec.json
+
+# Intermediary HTML assets
+assets/*.html

--- a/bin/diagrams
+++ b/bin/diagrams
@@ -19,7 +19,7 @@ const template = chart => `
       .node {
         text-align: center;
       }
-      
+
       i.fa {
         display: block;
         margin: 5px;
@@ -35,6 +35,7 @@ const template = chart => `
     <script>
       const diagram = document.createElement('div');
 
+      /* TODO (indexzero): parameterize this */
       window.mermaid.mermaidAPI.initialize({ theme: 'forest' });
       window.mermaid.mermaidAPI.render('container', \`${chart}\`, svg => {
         diagram.innerHTML = svg;
@@ -50,20 +51,31 @@ const template = chart => `
 async function snapshot(browser, file) {
   try {
     const chart = await fs.readFile(path.join(source, file), 'utf-8');
-    const output = path.join(source, '..', `${ path.basename(file, '.mmd') }.png`);
+    const targetDir = path.join(source, '..');
+    const output = {
+      png: `${ path.basename(file, '.mmd') }.png`,
+      html: `${ path.basename(file, '.mmd') }.html`
+    };
+
+    console.log(`[${ file }]  Render to string`);
+    const rendered = template(chart);
+
+    if (process.env.DEBUG) {
+      console.log(`[${output.html}] Write file`);
+      await fs.writeFile(path.join(targetDir, output.html), rendered, 'utf8');
+    }
+
     const page = await browser.newPage();
-
-    console.log(`Rendering ${ file }`);
-
     await page.setViewport({ width: 1920, height: 1080 });
-    await page.setContent(template(chart), { waitUntil: ['networkidle0'] });
+    await page.setContent(rendered, { waitUntil: ['networkidle0'] });
 
     const clip = await page.$eval('svg', svg => {
       const box = svg.getBoundingClientRect();
       return { x: box.left, y: box.top, width: box.width, height: box.height };
     });
 
-    await page.screenshot({ path: output, clip, omitBackground: true });
+    console.log(`[${output.png}]  Screenshot result`);
+    await page.screenshot({ path: path.join(targetDir, output.png), clip, omitBackground: true });
   } catch (error) {
     throw new Error(`Snapshot of diagram failed: ${ error.message }`);
   }


### PR DESCRIPTION
## Summary

Was trying to improve these diagrams and needed to inspect the HTML output. This can now be accomplished by running:

``` bash
DEBUG=yes npm run diagrams
#
# *.html files are now located in ./assets/*.html
#
```

## Changelog

- Enable output of `*.html` files when `DEBUG=yes`. Slightly improved logging.

