### PR TITLE
Add proper swagger route for optional path variable `/assets/files` route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+- Add proper swagger route for optional path variable `/assets/files` route
 - [#57] Update `README.md`
   - Add badges
   - Add `promote` routes

--- a/lib/routes/assets.js
+++ b/lib/routes/assets.js
@@ -28,6 +28,37 @@ module.exports = function (app) {
   /**
    * API for serving latest files
    * @swagger
+   * /assets/files/{pkg}/{env}:
+   *   get:
+   *     summary: Gets the file assets for a given package-environment-version
+   *     security: []
+   *     produces:
+   *       - "application/json"
+   *     parameters:
+   *       - $ref: '#/parameters/Pkg'
+   *       - $ref: '#/parameters/Env'
+   *       - in: query
+   *         name: filter
+   *         required: false
+   *         schema:
+   *           type: string
+   *           maximum: 50
+   *         description: Case-insensitive substring filter to apply to the file list
+   *     responses:
+   *       200:
+   *         description: OK
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/Assets'
+   *       400:
+   *         description: Filter is too long
+   *       403:
+   *         $ref: '#/responses/Standard403'
+   *       404:
+   *         $ref: '#/responses/Standard404'
+   *       500:
+   *         $ref: '#/responses/Standard500'
    * /assets/files/{pkg}/{env}/{version}:
    *   get:
    *     summary: Gets the file assets for a given package-environment-version


### PR DESCRIPTION
## Summary

Swagger doesn't allow for optional path parameters, the route needs to be duplicated to achieve the same effect.

## Changelog

- Add proper swagger route for optional path variable `/assets/files` route

## Test Plan

N/A
