### PR TITLE
feat(plugin): add object API routes and models

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const createFastify = require('fastify');
 const pino = require('pino');
 const warehouse = require('./warehouse');

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,9 +1,20 @@
 const fp = require('fastify-plugin');
 
-module.exports = fp(async function (fastify) {
-  /* eslint-disable no-process-env */
-  fastify.decorate('config', {
-    port: process.env.PORT || 6666
-  });
-  /* eslint-enable no-process-env */
-});
+module.exports = fp(
+  async function (fastify) {
+    /* eslint-disable no-process-env */
+    fastify.decorate('config', {
+      port: process.env.PORT || 6666,
+      dynamo: {
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID, // optional
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY, // optional
+        region: process.env.AWS_REGION || 'us-west-2'
+      }
+    });
+    /* eslint-enable no-process-env */
+  },
+  {
+    fastify: '3.x',
+    name: 'config'
+  }
+);

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,12 +4,7 @@ module.exports = fp(
   async function (fastify) {
     /* eslint-disable no-process-env */
     fastify.decorate('config', {
-      port: process.env.PORT || 6666,
-      dynamo: {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID, // optional
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY, // optional
-        region: process.env.AWS_REGION || 'us-west-2'
-      }
+      port: process.env.PORT || 6666
     });
     /* eslint-enable no-process-env */
   },

--- a/lib/plugins/dynamo.js
+++ b/lib/plugins/dynamo.js
@@ -1,14 +1,17 @@
 const fp = require('fastify-plugin');
 const { DynamoDB } = require('aws-sdk');
 
-module.exports = fp(async function (fastify) {
-  const dynamo = new DynamoDB.DocumentClient(fastify.config.dynamo);
-  fastify.decorate('dynamo', dynamo);
-}, {
-  fastify: '3.x',
-  name: 'dynamo',
-  decorators: {
-    fastify: ['config']
+module.exports = fp(
+  async function (fastify) {
+    const dynamo = new DynamoDB.DocumentClient(fastify.config.dynamo);
+    fastify.decorate('dynamo', dynamo);
   },
-  dependencies: ['config']
-});
+  {
+    fastify: '3.x',
+    name: 'dynamo',
+    decorators: {
+      fastify: ['config']
+    },
+    dependencies: ['config']
+  }
+);

--- a/lib/plugins/dynamo.js
+++ b/lib/plugins/dynamo.js
@@ -3,7 +3,7 @@ const { DynamoDB } = require('aws-sdk');
 
 module.exports = fp(
   async function (fastify) {
-    const dynamo = new DynamoDB.DocumentClient(fastify.config.dynamo);
+    const dynamo = new DynamoDB.DocumentClient();
     fastify.decorate('dynamo', dynamo);
   },
   {

--- a/lib/plugins/dynamo.js
+++ b/lib/plugins/dynamo.js
@@ -2,16 +2,13 @@ const fp = require('fastify-plugin');
 const { DynamoDB } = require('aws-sdk');
 
 module.exports = fp(async function (fastify) {
-  /* eslint-disable no-process-env */
-  const dynamo = new DynamoDB.DocumentClient({
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID, // optional
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY, // optional
-    region: process.env.AWS_REGION || 'us-west-2'
-  });
-  /* eslint-enable no-process-env */
-
+  const dynamo = new DynamoDB.DocumentClient(fastify.config.dynamo);
   fastify.decorate('dynamo', dynamo);
 }, {
   fastify: '3.x',
-  name: 'dynamo'
+  name: 'dynamo',
+  decorators: {
+    fastify: ['config'],
+  },
+  dependencies: ['config']
 });

--- a/lib/plugins/dynamo.js
+++ b/lib/plugins/dynamo.js
@@ -8,7 +8,7 @@ module.exports = fp(async function (fastify) {
   fastify: '3.x',
   name: 'dynamo',
   decorators: {
-    fastify: ['config'],
+    fastify: ['config']
   },
   dependencies: ['config']
 });

--- a/lib/plugins/dynamo.js
+++ b/lib/plugins/dynamo.js
@@ -1,7 +1,17 @@
 const fp = require('fastify-plugin');
+const { DynamoDB } = require('aws-sdk');
 
 module.exports = fp(async function (fastify) {
-  // TODO(jdaeli): create an AWS.DynamoDB instance.
-  const dynamo = {};
+  /* eslint-disable no-process-env */
+  const dynamo = new DynamoDB.DocumentClient({
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID, // optional
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY, // optional
+    region: process.env.AWS_REGION || 'us-west-2'
+  });
+  /* eslint-enable no-process-env */
+
   fastify.decorate('dynamo', dynamo);
+}, {
+  fastify: '3.x',
+  name: 'dynamo'
 });

--- a/lib/plugins/object.js
+++ b/lib/plugins/object.js
@@ -1,0 +1,113 @@
+const fp = require('fastify-plugin');
+
+const OBJECTS_TABLE = 'warehouse-objects';
+const OBJECT_VARIANTS_TABLE = 'warehouse-object-variants';
+const OBJECTS_HISTORY_TABLE = 'warehouse-objects-history';
+
+module.exports = fp(async function (fastify) {
+  const { dynamo } = fastify; 
+
+  fastify.decorate('getObject', function ({
+    name,
+    env = 'production'
+  }) {
+    const params = {
+      Key: { name, env },
+      TableName: OBJECTS_TABLE
+    };
+    return dynamo.get(params).promise();
+  });
+
+  fastify.decorate('putObject', function ({
+    name,
+    latestVersion,
+    env = 'production',
+    headVersion = null,
+    headTimestamp = null
+  }) {
+    const now = new Date();
+    if (headVersion && !headTimestamp) {
+      headTimestamp = now.getTime();
+    }
+    const lastModified = now.toUTCString();
+    const params = {
+      Key: { name, env, latestVersion, headVersion, headTimestamp, lastModified },
+      TableName: OBJECTS_TABLE
+    };
+    return new Promise((resolve, reject) => {
+      dynamo.get(params, function (err, data) {
+        if (err) return reject(err);
+        resolve(data);
+      });
+    });
+  });
+
+  fastify.decorate('getObjectVariant', function ({
+    name,
+    version,
+    env = 'production',
+    variant = '_default'
+  }) {
+    const id = `${name}_${version}_${env}`;
+    const params = {
+      Key: { id, variant },
+      TableName: OBJECTS_TABLE
+    };
+    return dynamo.query(params).promise();
+  });
+
+  fastify.decorate('getObjectVariants', function ({
+    name,
+    version,
+    env = 'production'
+  }) {
+    const params = {
+      KeyConditionExpression: 'HashKey = :hkey',
+      ExpressionAttributeValues: {
+        ':hkey': `${name}_${version}_${env}`
+      },
+      TableName: OBJECT_VARIANTS_TABLE
+    };
+    return dynamo.query(params).promise();
+  });
+
+  fastify.decorate('putObjectVariant', function ({
+    name,
+    version,
+    env = 'production',
+    variant = '_default',
+    expiration = null,
+    data
+  }) {
+    const createdAt = new Date().toUTCString();
+    const id = `${name}_${version}_${env}`;
+    const params = {
+      Item: { id, name, version, env, variant, expiration, data, createdAt },
+      TableName: OBJECT_VARIANTS_TABLE
+    };
+    return dynamo.put(params).promise();
+  });
+
+  fastify.decorate('putObjectHistory', function ({
+    name,
+    headVersion,
+    env = 'production',
+    prevTimestamp = null
+  }) {
+    const timestamp = Date.now();
+    const id = `${name}_${env}`;
+    const params = {
+      Item: { id, timestamp, headVersion, prevTimestamp },
+      TableName: OBJECTS_HISTORY_TABLE
+    };
+    return dynamo.put(params).promise();
+  });
+
+}, {
+  fastify: '3.x',
+  name: 'object',
+  decorators: {
+    fastify: ['dynamo'],
+  },
+  dependencies: ['dynamo']
+});

--- a/lib/plugins/object.js
+++ b/lib/plugins/object.js
@@ -7,12 +7,13 @@ const OBJECTS_HISTORY_TABLE = 'warehouse-objects-history';
 module.exports = fp(async function (fastify) {
   const { dynamo } = fastify;
 
-  fastify.decorate('getObject', function ({ name, env }) {
+  fastify.decorate('getObject', async function ({ name, env }) {
     const params = {
       Key: { name, env },
       TableName: OBJECTS_TABLE
     };
-    return dynamo.get(params).promise();
+    const { Item: item } = await dynamo.get(params).promise();
+    return item;
   });
 
   fastify.decorate('putObject', function ({
@@ -39,7 +40,7 @@ module.exports = fp(async function (fastify) {
     });
   });
 
-  fastify.decorate('getObjectVariant', function ({
+  fastify.decorate('getObjectVariant', async function ({
     name,
     version,
     env,
@@ -50,10 +51,31 @@ module.exports = fp(async function (fastify) {
       Key: { id, variant },
       TableName: OBJECTS_TABLE
     };
-    return dynamo.query(params).promise();
+    const { Item: item } = await dynamo.get(params).promise();
+    return item;
   });
 
-  fastify.decorate('getObjectVariants', function ({
+  fastify.decorate('getObjectVariants', async function ({
+    name,
+    version,
+    env,
+    variants
+  }) {
+    const id = `${name}_${version}_${env}`;
+    const params = {
+      RequestItems: {
+        [OBJECTS_TABLE]: {
+          Keys: variants.map((variant) => {
+            return { id, variant }
+          })
+        }
+      }
+    };
+    const { Responses: results } = await dynamo.batchGet(params).promise();
+    return results.map((result) => result.Item);
+  });
+
+  fastify.decorate('getAllObjectVariants', async function ({
     name,
     version,
     env
@@ -65,7 +87,8 @@ module.exports = fp(async function (fastify) {
       },
       TableName: OBJECT_VARIANTS_TABLE
     };
-    return dynamo.query(params).promise();
+    const { Items: items } = await dynamo.query(params).promise();
+    return items;
   });
 
   fastify.decorate('putObjectVariant', function ({

--- a/lib/plugins/object.js
+++ b/lib/plugins/object.js
@@ -16,7 +16,7 @@ module.exports = fp(
        * @param {Object} opts Method parameters
        * @param {string} opts.name Object name
        * @param {string} opts.env Environment
-       * @returns {Promise<object>} The object
+       * @returns {Promise<Object>} The object
        */
       async function getObject({ name, env }) {
         const params = {
@@ -39,7 +39,7 @@ module.exports = fp(
        * @param {string} opts.env Environment
        * @param {string} opts.headVersion Current head object version
        * @param {number} opts.headTimestamp Timestamp of when the head has been set
-       * @returns {Promise<object>} The operation result
+       * @returns {Promise<Object>} The operation result
        */
       function putObject({
         name,
@@ -77,7 +77,7 @@ module.exports = fp(
        * @param {string} opts.name Object name
        * @param {string} opts.env Environment
        * @param {string} [opts.variant] Object variant
-       * @returns {Promise<object>} The object variant
+       * @returns {Promise<Object>} The object variant
        */
       async function getObjectVariant({
         name,
@@ -95,34 +95,32 @@ module.exports = fp(
       }
     );
 
-    /**
-     * Get multiple Object variants from the Ledger.
-     *
-     * @param {Object} opts Method parameters
-     * @param {string} opts.name Object name
-     * @param {string} opts.env Environment
-     * @param {string} [opts.variant] Object variant
-     * @returns {Promise<object>} List of object variants
-     */
-    fastify.decorate('getObjectVariants', async function ({
-      name,
-      version,
-      env,
-      variants
-    }) {
-      const id = `${name}_${version}_${env}`;
-      const params = {
-        RequestItems: {
-          [OBJECTS_TABLE]: {
-            Keys: variants.map((variant) => {
-              return { id, variant };
-            })
+    fastify.decorate(
+      'getObjectVariants',
+      /**
+       * Get multiple Object variants from the Ledger.
+       *
+       * @param {Object} opts Method parameters
+       * @param {string} opts.name Object name
+       * @param {string} opts.env Environment
+       * @param {string} [opts.variant] Object variant
+       * @returns {Promise<[Object]>} List of object variants
+       */
+      async function getObjectVariants({ name, version, env, variants }) {
+        const id = `${name}_${version}_${env}`;
+        const params = {
+          RequestItems: {
+            [OBJECTS_TABLE]: {
+              Keys: variants.map((variant) => {
+                return { id, variant };
+              })
+            }
           }
-        }
-      };
-      const { Responses: results } = await dynamo.batchGet(params).promise();
-      return results.map((result) => result.Item);
-    });
+        };
+        const { Responses: results } = await dynamo.batchGet(params).promise();
+        return results.map((result) => result.Item);
+      }
+    );
 
     /**
      * Get all Object variants from the Ledger.
@@ -131,7 +129,7 @@ module.exports = fp(
      * @param {string} opts.name Object name
      * @param {string} opts.env Environment
      * @param {string} [opts.variant] Object variant name. Default `_default`
-     * @returns {Promise<object>} List of all object variants
+     * @returns {Promise<[Object]>} List of all object variants
      */
     fastify.decorate(
       'getAllObjectVariants',
@@ -159,7 +157,7 @@ module.exports = fp(
        * @param {string} [opts.variant] Object variant name. Default `_default`
        * @param {string} opts.expiration Optional variant expiration. Default `never`
        * @param {any} opts.data Object variant data
-       * @returns {Promise<object>} The operation result
+       * @returns {Promise<Object>} The operation result
        */
       function putObjectVariant({
         name,
@@ -199,7 +197,7 @@ module.exports = fp(
        * @param {string} opts.name Object name
        * @param {string} opts.env Environment
        * @param {number} [opts.prevTimestamp] Previus changes timestamp
-       * @returns {Promise<object>} The operation result
+       * @returns {Promise<Object>} The operation result
        */
 
       function putObjectHistory({

--- a/lib/plugins/object.js
+++ b/lib/plugins/object.js
@@ -40,7 +40,7 @@ module.exports = fp(
         },
         TableName: OBJECTS_TABLE
       };
-      const { Item: item } = await dynamo.get(params).promise();
+      const { Item: item } = await dynamo.put(params).promise();
       return item;
     });
 

--- a/lib/plugins/object.js
+++ b/lib/plugins/object.js
@@ -11,7 +11,7 @@ module.exports = fp(
     fastify.decorate(
       'getObject',
       /**
-       * Get an Object from Storage.
+       * Get an Object from the Ledger.
        *
        * @param {Object} opts Method parameters
        * @param {string} opts.name Object name
@@ -28,47 +28,82 @@ module.exports = fp(
       }
     );
 
-    fastify.decorate('putObject', function ({
-      name,
-      latestVersion,
-      env,
-      headVersion = null,
-      headTimestamp = null
-    }) {
-      const now = new Date();
-      if (headVersion && !headTimestamp) {
-        headTimestamp = now.getTime();
+    fastify.decorate(
+      'putObject',
+      /**
+       * Put an Object into the Ledger.
+       *
+       * @param {Object} opts Method parameters
+       * @param {string} opts.name Object name
+       * @param {string} opts.latestVersion Latest object version
+       * @param {string} opts.env Environment
+       * @param {string} opts.headVersion Current head object version
+       * @param {number} opts.headTimestamp Timestamp of when the head has been set
+       * @returns {Promise<object>} The operation result
+       */
+      function putObject({
+        name,
+        latestVersion,
+        env,
+        headVersion = null,
+        headTimestamp = null
+      }) {
+        const now = new Date();
+        if (headVersion && !headTimestamp) {
+          headTimestamp = now.getTime();
+        }
+        const lastModified = now.toUTCString();
+        const params = {
+          Item: {
+            name,
+            env,
+            latestVersion,
+            headVersion,
+            headTimestamp,
+            lastModified
+          },
+          TableName: OBJECTS_TABLE
+        };
+        return dynamo.put(params).promise();
       }
-      const lastModified = now.toUTCString();
-      const params = {
-        Item: {
-          name,
-          env,
-          latestVersion,
-          headVersion,
-          headTimestamp,
-          lastModified
-        },
-        TableName: OBJECTS_TABLE
-      };
-      return dynamo.put(params).promise();
-    });
+    );
 
-    fastify.decorate('getObjectVariant', async function ({
-      name,
-      version,
-      env,
-      variant = '_default'
-    }) {
-      const id = `${name}_${version}_${env}`;
-      const params = {
-        Key: { id, variant },
-        TableName: OBJECTS_TABLE
-      };
-      const { Item: item } = await dynamo.get(params).promise();
-      return item;
-    });
+    fastify.decorate(
+      'getObjectVariant',
+      /**
+       * Get an Object variant from the Ledger.
+       *
+       * @param {Object} opts Method parameters
+       * @param {string} opts.name Object name
+       * @param {string} opts.env Environment
+       * @param {string} [opts.variant] Object variant
+       * @returns {Promise<object>} The object variant
+       */
+      async function getObjectVariant({
+        name,
+        version,
+        env,
+        variant = '_default'
+      }) {
+        const id = `${name}_${version}_${env}`;
+        const params = {
+          Key: { id, variant },
+          TableName: OBJECTS_TABLE
+        };
+        const { Item: item } = await dynamo.get(params).promise();
+        return item;
+      }
+    );
 
+    /**
+     * Get multiple Object variants from the Ledger.
+     *
+     * @param {Object} opts Method parameters
+     * @param {string} opts.name Object name
+     * @param {string} opts.env Environment
+     * @param {string} [opts.variant] Object variant
+     * @returns {Promise<object>} List of object variants
+     */
     fastify.decorate('getObjectVariants', async function ({
       name,
       version,
@@ -89,53 +124,99 @@ module.exports = fp(
       return results.map((result) => result.Item);
     });
 
-    fastify.decorate('getAllObjectVariants', async function ({
-      name,
-      version,
-      env
-    }) {
-      const params = {
-        KeyConditionExpression: 'HashKey = :hkey',
-        ExpressionAttributeValues: {
-          ':hkey': `${name}_${version}_${env}`
-        },
-        TableName: OBJECT_VARIANTS_TABLE
-      };
-      const { Items: items } = await dynamo.query(params).promise();
-      return items;
-    });
+    /**
+     * Get all Object variants from the Ledger.
+     *
+     * @param {Object} opts Method parameters
+     * @param {string} opts.name Object name
+     * @param {string} opts.env Environment
+     * @param {string} [opts.variant] Object variant name. Default `_default`
+     * @returns {Promise<object>} List of all object variants
+     */
+    fastify.decorate(
+      'getAllObjectVariants',
+      async function getAllObjectVariants({ name, version, env }) {
+        const params = {
+          KeyConditionExpression: 'HashKey = :hkey',
+          ExpressionAttributeValues: {
+            ':hkey': `${name}_${version}_${env}`
+          },
+          TableName: OBJECT_VARIANTS_TABLE
+        };
+        const { Items: items } = await dynamo.query(params).promise();
+        return items;
+      }
+    );
 
-    fastify.decorate('putObjectVariant', function ({
-      name,
-      version,
-      env,
-      variant = '_default',
-      expiration = null,
-      data
-    }) {
-      const createdAt = new Date().toUTCString();
-      const id = `${name}_${version}_${env}`;
-      const params = {
-        Item: { id, name, version, env, variant, expiration, data, createdAt },
-        TableName: OBJECT_VARIANTS_TABLE
-      };
-      return dynamo.put(params).promise();
-    });
+    fastify.decorate(
+      'putObjectVariant',
+      /**
+       * Put an Object variant into the Ledger.
+       *
+       * @param {Object} opts Method parameters
+       * @param {string} opts.name Object name
+       * @param {string} opts.env Environment
+       * @param {string} [opts.variant] Object variant name. Default `_default`
+       * @param {string} opts.expiration Optional variant expiration. Default `never`
+       * @param {any} opts.data Object variant data
+       * @returns {Promise<object>} The operation result
+       */
+      function putObjectVariant({
+        name,
+        version,
+        env,
+        variant = '_default',
+        expiration = null,
+        data
+      }) {
+        const createdAt = new Date().toUTCString();
+        const id = `${name}_${version}_${env}`;
+        const params = {
+          Item: {
+            id,
+            name,
+            version,
+            env,
+            variant,
+            expiration,
+            data,
+            createdAt
+          },
+          TableName: OBJECT_VARIANTS_TABLE
+        };
+        return dynamo.put(params).promise();
+      }
+    );
 
-    fastify.decorate('putObjectHistory', function ({
-      name,
-      headVersion,
-      env,
-      prevTimestamp = null
-    }) {
-      const timestamp = Date.now();
-      const id = `${name}_${env}`;
-      const params = {
-        Item: { id, timestamp, headVersion, prevTimestamp },
-        TableName: OBJECTS_HISTORY_TABLE
-      };
-      return dynamo.put(params).promise();
-    });
+    fastify.decorate(
+      'putObjectHistory',
+
+      /**
+       * Create an object history record to track object changes.
+       *
+       * @param {Object} opts Method parameters
+       * @param {string} opts.headVersion Head version
+       * @param {string} opts.name Object name
+       * @param {string} opts.env Environment
+       * @param {number} [opts.prevTimestamp] Previus changes timestamp
+       * @returns {Promise<object>} The operation result
+       */
+
+      function putObjectHistory({
+        name,
+        headVersion,
+        env,
+        prevTimestamp = null
+      }) {
+        const timestamp = Date.now();
+        const id = `${name}_${env}`;
+        const params = {
+          Item: { id, timestamp, headVersion, prevTimestamp },
+          TableName: OBJECTS_HISTORY_TABLE
+        };
+        return dynamo.put(params).promise();
+      }
+    );
   },
   {
     fastify: '3.x',

--- a/lib/plugins/object.js
+++ b/lib/plugins/object.js
@@ -4,130 +4,139 @@ const OBJECTS_TABLE = 'warehouse-objects';
 const OBJECT_VARIANTS_TABLE = 'warehouse-object-variants';
 const OBJECTS_HISTORY_TABLE = 'warehouse-objects-history';
 
-module.exports = fp(async function (fastify) {
-  const { dynamo } = fastify;
+module.exports = fp(
+  async function (fastify) {
+    const { dynamo } = fastify;
 
-  fastify.decorate('getObject', async function ({ name, env }) {
-    const params = {
-      Key: { name, env },
-      TableName: OBJECTS_TABLE
-    };
-    const { Item: item } = await dynamo.get(params).promise();
-    return item;
-  });
+    fastify.decorate('getObject', async function ({ name, env }) {
+      const params = {
+        Key: { name, env },
+        TableName: OBJECTS_TABLE
+      };
+      const { Item: item } = await dynamo.get(params).promise();
+      return item;
+    });
 
-  fastify.decorate('putObject', function ({
-    name,
-    latestVersion,
-    env,
-    headVersion = null,
-    headTimestamp = null
-  }) {
-    const now = new Date();
-    if (headVersion && !headTimestamp) {
-      headTimestamp = now.getTime();
-    }
-    const lastModified = now.toUTCString();
-    const params = {
-      Key: { name, env, latestVersion, headVersion, headTimestamp, lastModified },
-      TableName: OBJECTS_TABLE
-    };
-    return new Promise((resolve, reject) => {
-      dynamo.get(params, function (err, data) {
-        if (err) return reject(err);
-        resolve(data);
+    fastify.decorate('putObject', function ({
+      name,
+      latestVersion,
+      env,
+      headVersion = null,
+      headTimestamp = null
+    }) {
+      const now = new Date();
+      if (headVersion && !headTimestamp) {
+        headTimestamp = now.getTime();
+      }
+      const lastModified = now.toUTCString();
+      const params = {
+        Key: {
+          name,
+          env,
+          latestVersion,
+          headVersion,
+          headTimestamp,
+          lastModified
+        },
+        TableName: OBJECTS_TABLE
+      };
+      return new Promise((resolve, reject) => {
+        dynamo.get(params, function (err, data) {
+          if (err) return reject(err);
+          resolve(data);
+        });
       });
     });
-  });
 
-  fastify.decorate('getObjectVariant', async function ({
-    name,
-    version,
-    env,
-    variant = '_default'
-  }) {
-    const id = `${name}_${version}_${env}`;
-    const params = {
-      Key: { id, variant },
-      TableName: OBJECTS_TABLE
-    };
-    const { Item: item } = await dynamo.get(params).promise();
-    return item;
-  });
+    fastify.decorate('getObjectVariant', async function ({
+      name,
+      version,
+      env,
+      variant = '_default'
+    }) {
+      const id = `${name}_${version}_${env}`;
+      const params = {
+        Key: { id, variant },
+        TableName: OBJECTS_TABLE
+      };
+      const { Item: item } = await dynamo.get(params).promise();
+      return item;
+    });
 
-  fastify.decorate('getObjectVariants', async function ({
-    name,
-    version,
-    env,
-    variants
-  }) {
-    const id = `${name}_${version}_${env}`;
-    const params = {
-      RequestItems: {
-        [OBJECTS_TABLE]: {
-          Keys: variants.map((variant) => {
-            return { id, variant };
-          })
+    fastify.decorate('getObjectVariants', async function ({
+      name,
+      version,
+      env,
+      variants
+    }) {
+      const id = `${name}_${version}_${env}`;
+      const params = {
+        RequestItems: {
+          [OBJECTS_TABLE]: {
+            Keys: variants.map((variant) => {
+              return { id, variant };
+            })
+          }
         }
-      }
-    };
-    const { Responses: results } = await dynamo.batchGet(params).promise();
-    return results.map((result) => result.Item);
-  });
+      };
+      const { Responses: results } = await dynamo.batchGet(params).promise();
+      return results.map((result) => result.Item);
+    });
 
-  fastify.decorate('getAllObjectVariants', async function ({
-    name,
-    version,
-    env
-  }) {
-    const params = {
-      KeyConditionExpression: 'HashKey = :hkey',
-      ExpressionAttributeValues: {
-        ':hkey': `${name}_${version}_${env}`
-      },
-      TableName: OBJECT_VARIANTS_TABLE
-    };
-    const { Items: items } = await dynamo.query(params).promise();
-    return items;
-  });
+    fastify.decorate('getAllObjectVariants', async function ({
+      name,
+      version,
+      env
+    }) {
+      const params = {
+        KeyConditionExpression: 'HashKey = :hkey',
+        ExpressionAttributeValues: {
+          ':hkey': `${name}_${version}_${env}`
+        },
+        TableName: OBJECT_VARIANTS_TABLE
+      };
+      const { Items: items } = await dynamo.query(params).promise();
+      return items;
+    });
 
-  fastify.decorate('putObjectVariant', function ({
-    name,
-    version,
-    env,
-    variant = '_default',
-    expiration = null,
-    data
-  }) {
-    const createdAt = new Date().toUTCString();
-    const id = `${name}_${version}_${env}`;
-    const params = {
-      Item: { id, name, version, env, variant, expiration, data, createdAt },
-      TableName: OBJECT_VARIANTS_TABLE
-    };
-    return dynamo.put(params).promise();
-  });
+    fastify.decorate('putObjectVariant', function ({
+      name,
+      version,
+      env,
+      variant = '_default',
+      expiration = null,
+      data
+    }) {
+      const createdAt = new Date().toUTCString();
+      const id = `${name}_${version}_${env}`;
+      const params = {
+        Item: { id, name, version, env, variant, expiration, data, createdAt },
+        TableName: OBJECT_VARIANTS_TABLE
+      };
+      return dynamo.put(params).promise();
+    });
 
-  fastify.decorate('putObjectHistory', function ({
-    name,
-    headVersion,
-    env,
-    prevTimestamp = null
-  }) {
-    const timestamp = Date.now();
-    const id = `${name}_${env}`;
-    const params = {
-      Item: { id, timestamp, headVersion, prevTimestamp },
-      TableName: OBJECTS_HISTORY_TABLE
-    };
-    return dynamo.put(params).promise();
-  });
-
-}, {
-  fastify: '3.x',
-  name: 'object',
-  decorators: {
-    fastify: ['dynamo']
+    fastify.decorate('putObjectHistory', function ({
+      name,
+      headVersion,
+      env,
+      prevTimestamp = null
+    }) {
+      const timestamp = Date.now();
+      const id = `${name}_${env}`;
+      const params = {
+        Item: { id, timestamp, headVersion, prevTimestamp },
+        TableName: OBJECTS_HISTORY_TABLE
+      };
+      return dynamo.put(params).promise();
+    });
   },
-  dependencies: ['dynamo']
-});
+  {
+    fastify: '3.x',
+    name: 'object',
+    decorators: {
+      fastify: ['dynamo']
+    },
+    dependencies: ['dynamo']
+  }
+);

--- a/lib/plugins/object.js
+++ b/lib/plugins/object.js
@@ -7,10 +7,7 @@ const OBJECTS_HISTORY_TABLE = 'warehouse-objects-history';
 module.exports = fp(async function (fastify) {
   const { dynamo } = fastify;
 
-  fastify.decorate('getObject', function ({
-    name,
-    env = 'production'
-  }) {
+  fastify.decorate('getObject', function ({ name, env }) {
     const params = {
       Key: { name, env },
       TableName: OBJECTS_TABLE
@@ -21,7 +18,7 @@ module.exports = fp(async function (fastify) {
   fastify.decorate('putObject', function ({
     name,
     latestVersion,
-    env = 'production',
+    env,
     headVersion = null,
     headTimestamp = null
   }) {
@@ -45,7 +42,7 @@ module.exports = fp(async function (fastify) {
   fastify.decorate('getObjectVariant', function ({
     name,
     version,
-    env = 'production',
+    env,
     variant = '_default'
   }) {
     const id = `${name}_${version}_${env}`;
@@ -59,7 +56,7 @@ module.exports = fp(async function (fastify) {
   fastify.decorate('getObjectVariants', function ({
     name,
     version,
-    env = 'production'
+    env
   }) {
     const params = {
       KeyConditionExpression: 'HashKey = :hkey',
@@ -74,7 +71,7 @@ module.exports = fp(async function (fastify) {
   fastify.decorate('putObjectVariant', function ({
     name,
     version,
-    env = 'production',
+    env,
     variant = '_default',
     expiration = null,
     data
@@ -91,7 +88,7 @@ module.exports = fp(async function (fastify) {
   fastify.decorate('putObjectHistory', function ({
     name,
     headVersion,
-    env = 'production',
+    env,
     prevTimestamp = null
   }) {
     const timestamp = Date.now();

--- a/lib/plugins/object.js
+++ b/lib/plugins/object.js
@@ -5,7 +5,7 @@ const OBJECT_VARIANTS_TABLE = 'warehouse-object-variants';
 const OBJECTS_HISTORY_TABLE = 'warehouse-objects-history';
 
 module.exports = fp(async function (fastify) {
-  const { dynamo } = fastify; 
+  const { dynamo } = fastify;
 
   fastify.decorate('getObject', function ({
     name,
@@ -107,7 +107,7 @@ module.exports = fp(async function (fastify) {
   fastify: '3.x',
   name: 'object',
   decorators: {
-    fastify: ['dynamo'],
+    fastify: ['dynamo']
   },
   dependencies: ['dynamo']
 });

--- a/lib/plugins/object.js
+++ b/lib/plugins/object.js
@@ -40,12 +40,8 @@ module.exports = fp(
         },
         TableName: OBJECTS_TABLE
       };
-      return new Promise((resolve, reject) => {
-        dynamo.get(params, function (err, data) {
-          if (err) return reject(err);
-          resolve(data);
-        });
-      });
+      const { Item: item } = await dynamo.get(params).promise();
+      return item;
     });
 
     fastify.decorate('getObjectVariant', async function ({

--- a/lib/plugins/object.js
+++ b/lib/plugins/object.js
@@ -30,7 +30,7 @@ module.exports = fp(
       }
       const lastModified = now.toUTCString();
       const params = {
-        Key: {
+        Item: {
           name,
           env,
           latestVersion,
@@ -40,8 +40,7 @@ module.exports = fp(
         },
         TableName: OBJECTS_TABLE
       };
-      const { Item: item } = await dynamo.put(params).promise();
-      return item;
+      return dynamo.put(params).promise();
     });
 
     fastify.decorate('getObjectVariant', async function ({

--- a/lib/plugins/object.js
+++ b/lib/plugins/object.js
@@ -66,7 +66,7 @@ module.exports = fp(async function (fastify) {
       RequestItems: {
         [OBJECTS_TABLE]: {
           Keys: variants.map((variant) => {
-            return { id, variant }
+            return { id, variant };
           })
         }
       }

--- a/lib/plugins/object.js
+++ b/lib/plugins/object.js
@@ -8,14 +8,25 @@ module.exports = fp(
   async function (fastify) {
     const { dynamo } = fastify;
 
-    fastify.decorate('getObject', async function ({ name, env }) {
-      const params = {
-        Key: { name, env },
-        TableName: OBJECTS_TABLE
-      };
-      const { Item: item } = await dynamo.get(params).promise();
-      return item;
-    });
+    fastify.decorate(
+      'getObject',
+      /**
+       * Get an Object from Storage.
+       *
+       * @param {Object} opts Method parameters
+       * @param {string} opts.name Object name
+       * @param {string} opts.env Environment
+       * @returns {Promise<object>} The object
+       */
+      async function getObject({ name, env }) {
+        const params = {
+          Key: { name, env },
+          TableName: OBJECTS_TABLE
+        };
+        const { Item: item } = await dynamo.get(params).promise();
+        return item;
+      }
+    );
 
     fastify.decorate('putObject', function ({
       name,

--- a/lib/routes/objects.js
+++ b/lib/routes/objects.js
@@ -15,8 +15,12 @@ module.exports = async function (fastify) {
         }
       }
     },
-    handler: (req, res) => {
-      req.log.info('Objects API hit!');
+    handler: async (req, res) => {
+      const {
+        query: { version, accepted_variants: acceptedVariants, env = 'producton' }
+      } = req;
+
+      const variants = acceptedVariants ? acceptedVariants.split(',') : null;
       res.send({ get: true });
     }
   });

--- a/lib/routes/objects.js
+++ b/lib/routes/objects.js
@@ -17,12 +17,29 @@ module.exports = async function (fastify) {
     },
     handler: async (req, res) => {
       const {
-        query: { version, accepted_variants: acceptedVariants, env = 'producton' }
+        params: { name },
+        query: { version: v, accepted_variants: acceptedVariants, env = 'producton' }
       } = req;
 
       const variants = acceptedVariants ? acceptedVariants.split(',') : null;
 
-      res.send({ get: true });
+      let version = v;
+      if (!version) {
+        const obj = await fastify.getObject({ name, env });
+        if (!obj) {
+          throw fastify.httpErrors.notFound();
+        }
+        version = obj.latestVersion;
+      }
+
+      let objectVariants;
+      if (!variants) {
+        objectVariants = await fastify.getAllObjectVariants({ name, env, version });
+      } else {
+        objectVariants = await fastify.getObjectVariants({ name, env, version, variants });
+      }
+
+      res.send(objectVariants);
     }
   });
 

--- a/lib/routes/objects.js
+++ b/lib/routes/objects.js
@@ -2,9 +2,7 @@ module.exports = async function (fastify) {
   fastify.route({
     method: 'GET',
     url: '/objects/:name',
-    preHandler: fastify.auth([
-      fastify.verifyAuthentication
-    ]),
+    preHandler: fastify.auth([fastify.verifyAuthentication]),
     schema: {
       querystring: {
         type: 'object',
@@ -18,10 +16,19 @@ module.exports = async function (fastify) {
     handler: async (req, res) => {
       const {
         params: { name },
-        query: { version: v, accepted_variants: acceptedVariants, env = 'producton' }
+        query: {
+          version: v,
+          accepted_variants: acceptedVariants,
+          env = 'producton'
+        }
       } = req;
 
-      const variants = acceptedVariants ? acceptedVariants.split(',') : null;
+      const variants = acceptedVariants
+        ? acceptedVariants
+          .split(',')
+          .map((variant) => variant.trim())
+          .filter((variant) => variant !== '')
+        : null;
 
       let version = v;
       if (!version) {
@@ -34,9 +41,18 @@ module.exports = async function (fastify) {
 
       let objectVariants;
       if (!variants) {
-        objectVariants = await fastify.getAllObjectVariants({ name, env, version });
+        objectVariants = await fastify.getAllObjectVariants({
+          name,
+          env,
+          version
+        });
       } else {
-        objectVariants = await fastify.getObjectVariants({ name, env, version, variants });
+        objectVariants = await fastify.getObjectVariants({
+          name,
+          env,
+          version,
+          variants
+        });
       }
 
       res.send(objectVariants);
@@ -46,9 +62,7 @@ module.exports = async function (fastify) {
   fastify.route({
     method: 'POST',
     url: '/objects',
-    preHandler: fastify.auth([
-      fastify.verifyAuthentication
-    ]),
+    preHandler: fastify.auth([fastify.verifyAuthentication]),
     schema: {
       body: {
         type: 'object',
@@ -72,9 +86,7 @@ module.exports = async function (fastify) {
   fastify.route({
     method: 'DELETE',
     url: '/objects/:name/:env',
-    preHandler: fastify.auth([
-      fastify.verifyAuthentication
-    ]),
+    preHandler: fastify.auth([fastify.verifyAuthentication]),
     handler: (req, res) => {
       req.log.info('Objects API hit!');
       res.send({ delete: true });
@@ -84,9 +96,7 @@ module.exports = async function (fastify) {
   fastify.route({
     method: 'DELETE',
     url: '/objects/:name/:env/:version',
-    preHandler: fastify.auth([
-      fastify.verifyAuthentication
-    ]),
+    preHandler: fastify.auth([fastify.verifyAuthentication]),
     schema: {
       querystring: {
         type: 'object',
@@ -104,9 +114,7 @@ module.exports = async function (fastify) {
   fastify.route({
     method: 'PUT',
     url: '/objects/:name/:env',
-    preHandler: fastify.auth([
-      fastify.verifyAuthentication
-    ]),
+    preHandler: fastify.auth([fastify.verifyAuthentication]),
     schema: {
       body: {
         type: 'object',

--- a/lib/routes/objects.js
+++ b/lib/routes/objects.js
@@ -23,13 +23,6 @@ module.exports = async function (fastify) {
         }
       } = req;
 
-      const variants = acceptedVariants
-        ? acceptedVariants
-          .split(',')
-          .map((variant) => variant.trim())
-          .filter((variant) => variant !== '')
-        : null;
-
       let version = v;
       if (!version) {
         const obj = await fastify.getObject({ name, env });
@@ -38,6 +31,13 @@ module.exports = async function (fastify) {
         }
         version = obj.latestVersion;
       }
+
+      const variants = acceptedVariants
+        ? acceptedVariants
+          .split(',')
+          .map((variant) => variant.trim())
+          .filter((variant) => variant !== '')
+        : null;
 
       let objectVariants;
       if (!variants) {

--- a/lib/routes/objects.js
+++ b/lib/routes/objects.js
@@ -1,10 +1,46 @@
 module.exports = async function (fastify) {
   fastify.route({
     method: 'GET',
+    url: '/objects/:name',
+    preHandler: fastify.auth([
+      fastify.verifyAuthentication
+    ]),
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          accepted_variants: { type: 'string' },
+          version: { type: 'string' },
+          env: { type: 'string' }
+        }
+      }
+    },
+    handler: (req, res) => {
+      req.log.info('Objects API hit!');
+      res.send({ objects: true });
+    }
+  });
+
+  fastify.route({
+    method: 'POST',
     url: '/objects',
     preHandler: fastify.auth([
       fastify.verifyAuthentication
     ]),
+    schema: {
+      body: {
+        type: 'object',
+        required: ['accepted_variants', 'version', 'env', 'data'],
+        properties: {
+          name: { type: 'string' },
+          version: { type: 'string' },
+          env: { type: 'string' },
+          variant: { type: 'string' },
+          expiration: { type: ['string', 'number'] },
+          data: { type: ['object', 'string'] }
+        }
+      }
+    },
     handler: (req, res) => {
       req.log.info('Objects API hit!');
       res.send({ objects: true });

--- a/lib/routes/objects.js
+++ b/lib/routes/objects.js
@@ -21,6 +21,7 @@ module.exports = async function (fastify) {
       } = req;
 
       const variants = acceptedVariants ? acceptedVariants.split(',') : null;
+
       res.send({ get: true });
     }
   });

--- a/lib/routes/objects.js
+++ b/lib/routes/objects.js
@@ -17,7 +17,7 @@ module.exports = async function (fastify) {
     },
     handler: (req, res) => {
       req.log.info('Objects API hit!');
-      res.send({ objects: true });
+      res.send({ get: true });
     }
   });
 
@@ -30,7 +30,7 @@ module.exports = async function (fastify) {
     schema: {
       body: {
         type: 'object',
-        required: ['accepted_variants', 'version', 'env', 'data'],
+        required: ['name', 'version', 'env', 'data'],
         properties: {
           name: { type: 'string' },
           version: { type: 'string' },
@@ -43,7 +43,60 @@ module.exports = async function (fastify) {
     },
     handler: (req, res) => {
       req.log.info('Objects API hit!');
-      res.send({ objects: true });
+      res.send({ post: true });
+    }
+  });
+
+  fastify.route({
+    method: 'DELETE',
+    url: '/objects/:name/:env',
+    preHandler: fastify.auth([
+      fastify.verifyAuthentication
+    ]),
+    handler: (req, res) => {
+      req.log.info('Objects API hit!');
+      res.send({ delete: true });
+    }
+  });
+
+  fastify.route({
+    method: 'DELETE',
+    url: '/objects/:name/:env/:version',
+    preHandler: fastify.auth([
+      fastify.verifyAuthentication
+    ]),
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          variant: { type: 'string' }
+        }
+      }
+    },
+    handler: (req, res) => {
+      req.log.info('Objects API hit!');
+      res.send({ deleteAgain: true });
+    }
+  });
+
+  fastify.route({
+    method: 'PUT',
+    url: '/objects/:name/:env',
+    preHandler: fastify.auth([
+      fastify.verifyAuthentication
+    ]),
+    schema: {
+      body: {
+        type: 'object',
+        required: ['head'],
+        properties: {
+          head: { type: 'string' }
+        }
+      }
+    },
+    handler: (req, res) => {
+      req.log.info('Objects API hit!');
+      res.send({ put: true });
     }
   });
 };

--- a/lib/warehouse.js
+++ b/lib/warehouse.js
@@ -1,6 +1,7 @@
 const fastifyAuth = require('fastify-auth');
 const AutoLoad = require('fastify-autoload');
 const fp = require('fastify-plugin');
+const fastifySensible = require('fastify-sensible');
 const path = require('path');
 
 const config = require('./config');
@@ -9,7 +10,8 @@ module.exports = fp(
   async function (fastify) {
     await Promise.all([
       fastify.register(config),
-      fastify.register(fastifyAuth)
+      fastify.register(fastifyAuth),
+      fastify.register(fastifySensible)
     ]);
 
     await fastify.after();

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.11.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-      "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
+      "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.11.5",
+        "@babel/types": "^7.12.5",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -92,9 +92,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-      "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
+      "integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
       "dev": true
     },
     "@babel/template": {
@@ -109,17 +109,17 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-      "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
+      "integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.5",
+        "@babel/generator": "^7.12.5",
         "@babel/helper-function-name": "^7.10.4",
         "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.11.5",
-        "@babel/types": "^7.11.5",
+        "@babel/parser": "^7.12.5",
+        "@babel/types": "^7.12.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
@@ -134,9 +134,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-      "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+      "version": "7.12.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
+      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
@@ -145,9 +145,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
-      "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.1.tgz",
+      "integrity": "sha512-XRUeBZ5zBWLYgSANMpThFddrZZkEbGHgUdt5UJjZfnlN9BGCiUBrf+nvbRupSjMvqzwnQN0qwCmOxITt1cfywA==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -211,9 +211,9 @@
       "dev": true
     },
     "abstract-logging": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.0.tgz",
-      "integrity": "sha512-/oA9z7JszpIioo6J6dB79LVUgJ3eD3cxkAmdCkvWWS+Y9tPtALs1rLqOekLUXUbYqM2fB9TTK0ibAyZJJOP/CA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
     },
     "acorn": {
       "version": "7.4.1",
@@ -234,9 +234,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -429,32 +429,6 @@
         "url": "0.10.3",
         "uuid": "3.3.2",
         "xml2js": "0.4.19"
-      },
-      "dependencies": {
-        "sax": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        },
-        "xml2js": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-          "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-          "requires": {
-            "sax": ">=0.6.0",
-            "xmlbuilder": "~9.0.1"
-          }
-        },
-        "xmlbuilder": {
-          "version": "9.0.7",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-        }
       }
     },
     "aws-sign2": {
@@ -464,9 +438,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
     "balanced-match": {
@@ -700,13 +674,6 @@
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        }
       }
     },
     "buffer-from": {
@@ -810,12 +777,6 @@
         "readable-stream": "> 1.0.0 < 3.0.0"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -945,9 +906,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
@@ -957,7 +918,7 @@
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.4.0"
+        "readdirp": "~3.5.0"
       }
     },
     "ci-info": {
@@ -1146,9 +1107,9 @@
       }
     },
     "conventional-changelog-angular": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz",
-      "integrity": "sha512-nSLypht/1yEflhuTogC03i7DX7sOrXGsRn14g131Potqi6cbGbGEE9PSDEHKldabB6N76HiSyw9Ph+kLmC04Qw==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.12.tgz",
+      "integrity": "sha512-5GLsbnkR/7A89RyHLvvoExbiGbd9xKdKqDTrArnPbOqBqG/2wIosu0fHwpeIRI8Tl94MhVNBXcLJZl92ZQ5USw==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
@@ -1156,18 +1117,18 @@
       }
     },
     "conventional-changelog-atom": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.7.tgz",
-      "integrity": "sha512-7dOREZwzB+tCEMjRTDfen0OHwd7vPUdmU0llTy1eloZgtOP4iSLVzYIQqfmdRZEty+3w5Jz+AbhfTJKoKw1JeQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.8.tgz",
+      "integrity": "sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==",
       "dev": true,
       "requires": {
         "q": "^1.5.1"
       }
     },
     "conventional-changelog-codemirror": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.7.tgz",
-      "integrity": "sha512-Oralk1kiagn3Gb5cR5BffenWjVu59t/viE6UMD/mQa1hISMPkMYhJIqX+CMeA1zXgVBO+YHQhhokEj99GP5xcg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.8.tgz",
+      "integrity": "sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==",
       "dev": true,
       "requires": {
         "q": "^1.5.1"
@@ -1191,80 +1152,79 @@
       }
     },
     "conventional-changelog-core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.0.tgz",
-      "integrity": "sha512-8+xMvN6JvdDtPbGBqA7oRNyZD4od1h/SIzrWqHcKZjitbVXrFpozEeyn4iI4af1UwdrabQpiZMaV07fPUTGd4w==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.1.tgz",
+      "integrity": "sha512-8cH8/DEoD3e5Q6aeogdR5oaaKs0+mG6+f+Om0ZYt3PNv7Zo0sQhu4bMDRsqAF+UTekTAtP1W/C41jH/fkm8Jtw==",
       "dev": true,
       "requires": {
         "add-stream": "^1.0.0",
-        "conventional-changelog-writer": "^4.0.17",
-        "conventional-commits-parser": "^3.1.0",
+        "conventional-changelog-writer": "^4.0.18",
+        "conventional-commits-parser": "^3.2.0",
         "dateformat": "^3.0.0",
         "get-pkg-repo": "^1.0.0",
         "git-raw-commits": "2.0.0",
         "git-remote-origin-url": "^2.0.0",
-        "git-semver-tags": "^4.1.0",
+        "git-semver-tags": "^4.1.1",
         "lodash": "^4.17.15",
-        "normalize-package-data": "^2.3.5",
+        "normalize-package-data": "^3.0.0",
         "q": "^1.5.1",
         "read-pkg": "^3.0.0",
         "read-pkg-up": "^3.0.0",
         "shelljs": "^0.8.3",
-        "through2": "^3.0.0"
+        "through2": "^4.0.0"
       },
       "dependencies": {
         "through2": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+          "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "2 || 3"
+            "readable-stream": "3"
           }
         }
       }
     },
     "conventional-changelog-ember": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.8.tgz",
-      "integrity": "sha512-JEMEcUAMg4Q9yxD341OgWlESQ4gLqMWMXIWWUqoQU8yvTJlKnrvcui3wk9JvnZQyONwM2g1MKRZuAjKxr8hAXA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.9.tgz",
+      "integrity": "sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==",
       "dev": true,
       "requires": {
         "q": "^1.5.1"
       }
     },
     "conventional-changelog-eslint": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.8.tgz",
-      "integrity": "sha512-5rTRltgWG7TpU1PqgKHMA/2ivjhrB+E+S7OCTvj0zM/QGg4vmnVH67Vq/EzvSNYtejhWC+OwzvDrLk3tqPry8A==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.9.tgz",
+      "integrity": "sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==",
       "dev": true,
       "requires": {
         "q": "^1.5.1"
       }
     },
     "conventional-changelog-express": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.5.tgz",
-      "integrity": "sha512-pW2hsjKG+xNx/Qjof8wYlAX/P61hT5gQ/2rZ2NsTpG+PgV7Rc8RCfITvC/zN9K8fj0QmV6dWmUefCteD9baEAw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.6.tgz",
+      "integrity": "sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==",
       "dev": true,
       "requires": {
         "q": "^1.5.1"
       }
     },
     "conventional-changelog-jquery": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.10.tgz",
-      "integrity": "sha512-QCW6wF8QgPkq2ruPaxc83jZxoWQxLkt/pNxIDn/oYjMiVgrtqNdd7lWe3vsl0hw5ENHNf/ejXuzDHk6suKsRpg==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.11.tgz",
+      "integrity": "sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==",
       "dev": true,
       "requires": {
         "q": "^1.5.1"
       }
     },
     "conventional-changelog-jshint": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.8.tgz",
-      "integrity": "sha512-hB/iI0IiZwnZ+seYI+qEQ4b+EMQSEC8jGIvhO2Vpz1E5p8FgLz75OX8oB1xJWl+s4xBMB6f8zJr0tC/BL7YOjw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.9.tgz",
+      "integrity": "sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
@@ -1278,21 +1238,21 @@
       "dev": true
     },
     "conventional-changelog-writer": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.17.tgz",
-      "integrity": "sha512-IKQuK3bib/n032KWaSb8YlBFds+aLmzENtnKtxJy3+HqDq5kohu3g/UdNbIHeJWygfnEbZjnCKFxAW0y7ArZAw==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.18.tgz",
+      "integrity": "sha512-mAQDCKyB9HsE8Ko5cCM1Jn1AWxXPYV0v8dFPabZRkvsiWUul2YyAqbIaoMKF88Zf2ffnOPSvKhboLf3fnjo5/A==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
-        "conventional-commits-filter": "^2.0.6",
+        "conventional-commits-filter": "^2.0.7",
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.6",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.15",
-        "meow": "^7.0.0",
+        "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
-        "through2": "^3.0.0"
+        "through2": "^4.0.0"
       },
       "dependencies": {
         "semver": {
@@ -1302,21 +1262,20 @@
           "dev": true
         },
         "through2": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+          "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "2 || 3"
+            "readable-stream": "3"
           }
         }
       }
     },
     "conventional-commits-filter": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.6.tgz",
-      "integrity": "sha512-4g+sw8+KA50/Qwzfr0hL5k5NWxqtrOVw4DDk3/h6L85a9Gz0/Eqp3oP+CWCNfesBvZZZEFHF7OTEbRe+yYSyKw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
+      "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
       "dev": true,
       "requires": {
         "lodash.ismatch": "^4.4.0",
@@ -1324,26 +1283,20 @@
       }
     },
     "conventional-commits-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.1.0.tgz",
-      "integrity": "sha512-RSo5S0WIwXZiRxUGTPuYFbqvrR4vpJ1BDdTlthFgvHt5kEdnd1+pdvwWphWn57/oIl4V72NMmOocFqqJ8mFFhA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.0.tgz",
+      "integrity": "sha512-XmJiXPxsF0JhAKyfA2Nn+rZwYKJ60nanlbSWwwkGwLQFbugsc0gv1rzc7VbbUWAzJfR1qR87/pNgv9NgmxtBMQ==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.4",
         "is-text-path": "^1.0.1",
         "lodash": "^4.17.15",
-        "meow": "^7.0.0",
+        "meow": "^8.0.0",
         "split2": "^2.0.0",
-        "through2": "^3.0.0",
+        "through2": "^4.0.0",
         "trim-off-newlines": "^1.0.0"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -1396,13 +1349,25 @@
           }
         },
         "through2": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+          "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "2 || 3"
+            "readable-stream": "3"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            }
           }
         }
       }
@@ -1421,6 +1386,140 @@
         "git-semver-tags": "^4.1.0",
         "meow": "^7.0.0",
         "q": "^1.5.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "meow": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
+          "integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
+          "dev": true,
+          "requires": {
+            "@types/minimist": "^1.2.0",
+            "camelcase-keys": "^6.2.2",
+            "decamelize-keys": "^1.1.0",
+            "hard-rejection": "^2.1.0",
+            "minimist-options": "4.1.0",
+            "normalize-package-data": "^2.5.0",
+            "read-pkg-up": "^7.0.1",
+            "redent": "^3.0.0",
+            "trim-newlines": "^3.0.0",
+            "type-fest": "^0.13.1",
+            "yargs-parser": "^18.1.3"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+              "dev": true
+            }
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "convert-source-map": {
@@ -1688,8 +1787,7 @@
     "dotenv": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
-      "dev": true
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "dotgitignore": {
       "version": "2.1.0",
@@ -1738,12 +1836,6 @@
         "stream-shift": "^1.0.0"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -1838,13 +1930,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.10.0.tgz",
-      "integrity": "sha512-BDVffmqWl7JJXqCjAK6lWtcQThZB/aP1HXSH1JKwGwv0LQEdvpR7qzNrUT487RM39B5goWuboFad5ovMBmD8yA==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.12.1.tgz",
+      "integrity": "sha512-HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.1.3",
+        "@eslint/eslintrc": "^0.2.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -1853,7 +1945,7 @@
         "enquirer": "^2.3.5",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^1.3.0",
+        "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.0",
         "esquery": "^1.2.0",
         "esutils": "^2.0.2",
@@ -1941,12 +2033,20 @@
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
     "esm": {
@@ -1964,6 +2064,14 @@
         "acorn": "^7.4.0",
         "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -2083,9 +2191,9 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-json-stringify": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.2.7.tgz",
-      "integrity": "sha512-XVCR/dQ6unMP7c39XUdnPoYPPnf1RqTZGL2mAnmrXDIkyF5MRJYd87nfCEmxrqhj7k61Yi35Aaeb2QlJlZU9fg==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.2.9.tgz",
+      "integrity": "sha512-O8YmNoc7LnfSafVaTfa1yXVFT4UMsi/N7cYcNZw6w5D5tltyu6XGXvH45mvWfsrcFoSK+H0q0exGXsUqC18z/g==",
       "requires": {
         "ajv": "^6.11.0",
         "deepmerge": "^4.2.2",
@@ -2109,9 +2217,9 @@
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fastify": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.5.1.tgz",
-      "integrity": "sha512-SO/ZZSbbAUrRxxz9zIsf1Ek5qqRux5EN03UF1lJGt/xwFzVpmW4h+p8kRCD08VCL1sItFy2dhFlR8FPaQfRGBw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.7.0.tgz",
+      "integrity": "sha512-xmiR1TOSNXXNHfEvBwhWlyj158q59vZkPLIKQ71f7qJG5QMPqCbeYUUFRaDKTaLFhRqmLLFprBpJsO5nbSMiPQ==",
       "requires": {
         "abstract-logging": "^2.0.0",
         "ajv": "^6.12.2",
@@ -2121,7 +2229,7 @@
         "fastify-warning": "^0.2.0",
         "find-my-way": "^3.0.0",
         "flatstr": "^1.0.12",
-        "light-my-request": "^4.0.2",
+        "light-my-request": "^4.2.0",
         "pino": "^6.2.1",
         "proxy-addr": "^2.0.5",
         "readable-stream": "^3.4.0",
@@ -2150,9 +2258,9 @@
       }
     },
     "fastify-cli": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/fastify-cli/-/fastify-cli-2.3.0.tgz",
-      "integrity": "sha512-PEO9nd9E/pTveN1Zb6cF1NwHDpyV99Xx06mAxGW07xZropo0QZBqCL/CzIfeqaw71L3bJdrY/nEwKJYEpT4gMQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/fastify-cli/-/fastify-cli-2.5.1.tgz",
+      "integrity": "sha512-e2kpzybLRvFe0p+O+vH7SX+i61YA1W6odH0o+C9VFjDBAJ42AGL4bxgnOyIDynA6F/aSlsq9xpl1YxMIp1fQIw==",
       "dev": true,
       "requires": {
         "blessed": "^0.1.81",
@@ -2214,9 +2322,9 @@
       "integrity": "sha512-s1EQguBw/9qtc1p/WTY4eq9WMRIACkj+HTcOIK1in4MV5aFaQC9ZCIt0dJ7pr5bIf4lPpHvAtP2ywpTNgs7hqw=="
     },
     "fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -2284,9 +2392,9 @@
       }
     },
     "find-my-way": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-3.0.4.tgz",
-      "integrity": "sha512-Trl/mNAVvTgCpo9ox6yixkwiZUvecKYUQZoAuMCBACsgGqv+FbWe+jE5sBA5+U8LIWrJk/cw8zPV53GPrjTnsw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-3.0.5.tgz",
+      "integrity": "sha512-FweGg0cv1sBX8z7WhvBX5B5AECW4Zdh/NiB38Oa0qwSNIyPgRBCl/YjxuZn/rz38E/MMBHeVKJ22i7W3c626Gg==",
       "requires": {
         "fast-decode-uri-component": "^1.0.1",
         "safe-regex2": "^2.0.0",
@@ -2330,18 +2438,18 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.135.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.135.0.tgz",
-      "integrity": "sha512-ev8SvmG+XU9D6WgHVezP4kY3Myr1tJvTUTEi7mbhhj+rn889K7YXdakte6oqXNLIJYJ2f5Fuw18zXTVa1NO8Kw==",
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.137.0.tgz",
+      "integrity": "sha512-i3KXJZ8lhlQI0n+BoZzIeH/rv+fNvAiu1i9/s64MklBV+HuhFbycUML7367J2eng0gapLnwvYPFNaPZys8POsA==",
       "dev": true
     },
     "flow-remove-types": {
-      "version": "2.135.0",
-      "resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-2.135.0.tgz",
-      "integrity": "sha512-l/9INhkrrTD+91k35P0eiF94E1cOpjfd86WVVqRwQRjamjSwTKKgu7MDLel3DGmBB09I2AXv7IjacNiwt0yc1g==",
+      "version": "2.137.0",
+      "resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-2.137.0.tgz",
+      "integrity": "sha512-Ubj3M8kKv6rA5mxy9qVxKoZZ8COcFknUvwjUb1uxObrOLOhhZYeIrs//P6EUzd14cVKzhxPQ2Ey7b0DESq7VcA==",
       "dev": true,
       "requires": {
-        "flow-parser": "^0.135.0",
+        "flow-parser": "^0.137.0",
         "pirates": "^3.0.2",
         "vlq": "^0.2.1"
       }
@@ -2366,6 +2474,16 @@
             "which": "^1.2.9"
           }
         },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
         "which": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -2374,6 +2492,12 @@
           "requires": {
             "isexe": "^2.0.0"
           }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
         }
       }
     },
@@ -2426,6 +2550,12 @@
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "function-loop": {
       "version": "1.0.2",
@@ -2497,6 +2627,12 @@
             "pinkie-promise": "^2.0.0"
           }
         },
+        "hosted-git-info": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+          "dev": true
+        },
         "indent-string": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
@@ -2528,6 +2664,18 @@
             "read-pkg-up": "^1.0.1",
             "redent": "^1.0.0",
             "trim-newlines": "^1.0.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "path-exists": {
@@ -2569,6 +2717,12 @@
             "indent-string": "^2.1.0",
             "strip-indent": "^1.0.1"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         },
         "strip-indent": {
           "version": "1.0.1",
@@ -2641,6 +2795,12 @@
             "quick-lru": "^1.0.0"
           }
         },
+        "hosted-git-info": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+          "dev": true
+        },
         "indent-string": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
@@ -2680,6 +2840,18 @@
             "is-plain-obj": "^1.1.0"
           }
         },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
         "quick-lru": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
@@ -2695,6 +2867,12 @@
             "indent-string": "^3.0.0",
             "strip-indent": "^2.0.0"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         },
         "split2": {
           "version": "2.2.0",
@@ -2730,12 +2908,12 @@
       }
     },
     "git-semver-tags": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.0.tgz",
-      "integrity": "sha512-TcxAGeo03HdErzKzi4fDD+xEL7gi8r2Y5YSxH6N2XYdVSV5UkBwfrt7Gqo1b+uSHCjy/sa9Y6BBBxxFLxfbhTg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.1.tgz",
+      "integrity": "sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==",
       "dev": true,
       "requires": {
-        "meow": "^7.0.0",
+        "meow": "^8.0.0",
         "semver": "^6.0.0"
       },
       "dependencies": {
@@ -2821,12 +2999,6 @@
           "requires": {
             "is-extglob": "^2.1.0"
           }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
         },
         "readable-stream": {
           "version": "2.3.7",
@@ -2946,6 +3118,15 @@
       "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
       "dev": true
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -3003,10 +3184,13 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-      "dev": true
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
+      "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -3061,9 +3245,9 @@
       "dev": true
     },
     "import-fresh": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -3152,6 +3336,15 @@
       "dev": true,
       "requires": {
         "ci-info": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+      "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "is-docker": {
@@ -3291,10 +3484,9 @@
       "dev": true
     },
     "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isbinaryfile": {
       "version": "4.0.6",
@@ -3745,9 +3937,9 @@
       }
     },
     "light-my-request": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-4.1.1.tgz",
-      "integrity": "sha512-4H0T0PQcFB/fGTIkNV5ShuftWnuUKdtLWq5t2zt+lwMWRZkVviTfmJqGOXeAAqkdREnGJQXa8zJ4wXJ0LrzrTA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-4.2.1.tgz",
+      "integrity": "sha512-33FZvX/418IEy0sXldsLiJifbS/ruttcVveTbbZ8sQVR2VSFPA39hBu/iF/hVkt/1V0N7CdTQg4jiiVPdGgW8A==",
       "requires": {
         "ajv": "^6.12.2",
         "cookie": "^0.4.0",
@@ -3876,13 +4068,12 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "yallist": "^4.0.0"
       }
     },
     "make-dir": {
@@ -3973,6 +4164,12 @@
         "readable-stream": "~1.0.2"
       },
       "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -4000,9 +4197,9 @@
       "dev": true
     },
     "meow": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
-      "integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-8.0.0.tgz",
+      "integrity": "sha512-nbsTRz2fwniJBFgUkcdISq8y/q9n9VbiHYbfwklFh5V4V2uAcxtKQkDc0yCLPM/kP0d+inZBewn3zJqewHE7kg==",
       "dev": true,
       "requires": {
         "@types/minimist": "^1.2.0",
@@ -4010,12 +4207,12 @@
         "decamelize-keys": "^1.1.0",
         "hard-rejection": "^2.1.0",
         "minimist-options": "4.1.0",
-        "normalize-package-data": "^2.5.0",
+        "normalize-package-data": "^3.0.0",
         "read-pkg-up": "^7.0.1",
         "redent": "^3.0.0",
         "trim-newlines": "^3.0.0",
-        "type-fest": "^0.13.1",
-        "yargs-parser": "^18.1.3"
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
       },
       "dependencies": {
         "find-up": {
@@ -4027,6 +4224,12 @@
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
           }
+        },
+        "hosted-git-info": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+          "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
@@ -4064,6 +4267,18 @@
             "type-fest": "^0.6.0"
           },
           "dependencies": {
+            "normalize-package-data": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+              "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+              "dev": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
             "type-fest": {
               "version": "0.6.0",
               "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
@@ -4091,21 +4306,17 @@
             }
           }
         },
-        "type-fest": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
+        "type-fest": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.0.tgz",
+          "integrity": "sha512-fbDukFPnJBdn2eZ3RR+5mK2slHLFd6gYHY7jna1KWWy4Yr4XysHuCdXRzy+RiG/HwG4WJat00vdC2UHky5eKiQ==",
+          "dev": true
         }
       }
     },
@@ -4176,14 +4387,6 @@
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
       }
     },
     "mkdirp": {
@@ -4246,9 +4449,9 @@
       "dev": true
     },
     "nodemon": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.4.tgz",
-      "integrity": "sha512-Ltced+hIfTmaS28Zjv1BM552oQ3dbwPqI4+zI0SLgq+wpJhSyqgYude/aZa/3i31VCQWMfXJVxvu86abcam3uQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.6.tgz",
+      "integrity": "sha512-4I3YDSKXg6ltYpcnZeHompqac4E6JeAMpGm8tJnB9Y3T0ehasLa4139dJOcCrB93HHrUMsCrKtoAlXTqT5n4AQ==",
       "dev": true,
       "requires": {
         "chokidar": "^3.2.2",
@@ -4259,8 +4462,8 @@
         "semver": "^5.7.1",
         "supports-color": "^5.5.0",
         "touch": "^3.1.0",
-        "undefsafe": "^2.0.2",
-        "update-notifier": "^4.0.0"
+        "undefsafe": "^2.0.3",
+        "update-notifier": "^4.1.0"
       },
       "dependencies": {
         "debug": {
@@ -4290,23 +4493,15 @@
       }
     },
     "normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
+      "integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
+        "hosted-git-info": "^3.0.6",
+        "resolve": "^1.17.0",
+        "semver": "^7.3.2",
         "validate-npm-package-license": "^3.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "normalize-path": {
@@ -4514,12 +4709,6 @@
         "readable-stream": "^2.0.1"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -5003,14 +5192,14 @@
       }
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
     },
     "pupa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.0.1.tgz",
-      "integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
       "dev": true,
       "requires": {
         "escape-goat": "^2.0.0"
@@ -5034,9 +5223,9 @@
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "queue-microtask": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.4.tgz",
-      "integrity": "sha512-eY/4Obve9cE5FK8YvC1cJsm5cr7XvAurul8UtBDJ2PR1p5NmAwHtvAt5ftcLtwYRCUKNhxCneZZlxmUDFoSeKA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.0.tgz",
+      "integrity": "sha512-J95OVUiS4b8qqmpqhCodN8yPpHG2mpZUPQ8tDGyIY0VhM+kBHszOuvsMJVGNQ1OH2BnTFbqz45i+2jGpDw9H0w=="
     },
     "quick-format-unescaped": {
       "version": "4.0.1",
@@ -5076,9 +5265,9 @@
       }
     },
     "react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -5103,6 +5292,12 @@
         "path-type": "^3.0.0"
       },
       "dependencies": {
+        "hosted-git-info": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+          "dev": true
+        },
         "load-json-file": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -5113,6 +5308,18 @@
             "parse-json": "^4.0.0",
             "pify": "^3.0.0",
             "strip-bom": "^3.0.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "parse-json": {
@@ -5138,6 +5345,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "strip-bom": {
@@ -5214,9 +5427,9 @@
       }
     },
     "readdirp": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
@@ -5345,11 +5558,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+      "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.0.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -5412,10 +5626,9 @@
       "dev": true
     },
     "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "secure-json-parse": {
       "version": "2.1.0",
@@ -7080,9 +7293,9 @@
       "dev": true
     },
     "term-size": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
-      "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
       "dev": true
     },
     "test-exclude": {
@@ -7137,12 +7350,6 @@
         "xtend": "~4.0.1"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -7260,6 +7467,14 @@
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
       }
     },
     "trim-newlines": {
@@ -7354,9 +7569,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.1.tgz",
-      "integrity": "sha512-OApPSuJcxcnewwjSGGfWOjx3oix5XpmrK9Z2j0fTRlHGoZ49IU6kExfZTM0++fCArOOCet+vIfWwFHbvWqwp6g==",
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.5.tgz",
+      "integrity": "sha512-btvv/baMqe7HxP7zJSF7Uc16h1mSfuuSplT0/qdjxseesDU+yYzH33eHBH+eMdeRXwujXspaCTooWHQVVBh09w==",
       "dev": true,
       "optional": true
     },
@@ -7406,6 +7621,12 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
           "dev": true
         },
         "strip-ansi": {
@@ -7516,6 +7737,13 @@
       "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "requires": {
         "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
       }
     },
     "url": {
@@ -7525,13 +7753,6 @@
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-        }
       }
     },
     "url-parse-lax": {
@@ -7549,15 +7770,14 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8-compile-cache": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -7593,9 +7813,9 @@
       "dev": true
     },
     "vscode-json-languageservice": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.9.0.tgz",
-      "integrity": "sha512-J+2rbntYRLNL9wk0D2iovWo1df3JwYM+5VvWl1omNUgw+XbgpNBwpFZ/TsC1pTCdmpu5RMatXooplXZ8l/Irsg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.10.0.tgz",
+      "integrity": "sha512-8IvuRSQnjznu+obqy6Dy4S4H68Ke7a3Kb+A0FcdctyAMAWEnrORpCpMOMqEYiPLm/OTYLVWJ7ql3qToDTozu4w==",
       "dev": true,
       "requires": {
         "jsonc-parser": "^2.3.1",
@@ -7799,20 +8019,18 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dev": true,
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.2",
@@ -7827,9 +8045,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yaml": {
@@ -7933,9 +8151,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.1.tgz",
-      "integrity": "sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA==",
+      "version": "20.2.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
+      "integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==",
       "dev": true
     },
     "yn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -410,6 +410,48 @@
         "queue-microtask": "^1.1.2"
       }
     },
+    "aws-sdk": {
+      "version": "2.786.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.786.0.tgz",
+      "integrity": "sha512-oL+rDkoBdn0Q3AxiEzSemCE3WqW6kBf0A72SIjDQZJb4/NDvA2mL2rpNQGaxaFX3zMHEwfUGcMu7T3q7I6Q0lw==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "xml2js": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+          "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+          "requires": {
+            "sax": ">=0.6.0",
+            "xmlbuilder": "~9.0.1"
+          }
+        },
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -427,6 +469,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -639,6 +686,23 @@
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        }
+      }
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1964,6 +2028,11 @@
         }
       }
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "events-to-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
@@ -2938,6 +3007,11 @@
         "sshpk": "^1.7.0"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -3489,6 +3563,11 @@
           }
         }
       }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -4780,6 +4859,12 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true
+    },
     "prettier-bytes": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prettier-bytes/-/prettier-bytes-1.0.4.tgz",
@@ -4903,6 +4988,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "queue-microtask": {
       "version": "1.1.4",
@@ -7363,6 +7453,22 @@
       "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
       }
     },
     "url-parse-lax": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -183,6 +183,11 @@
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
       "dev": true
     },
+    "@types/node": {
+      "version": "14.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -1633,6 +1638,11 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
     "detect-indent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
@@ -2182,6 +2192,20 @@
       "integrity": "sha512-I+Oaj6p9oiRozbam30sh39BiuiqBda7yK2nmSPVwDCfIBlKnT8YB3MY+pRQc2Fcd07bf6KPGklHJaQ2Qu81TYQ==",
       "requires": {
         "semver": "^7.3.2"
+      }
+    },
+    "fastify-sensible": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fastify-sensible/-/fastify-sensible-3.0.1.tgz",
+      "integrity": "sha512-XVgrQySnpNq6FTUEhLLyA0i6eB7DKF6OJV05gxCDQ008cEgzOs97L/TOd1tT3fgRf3Z6tyA2zb/wMdFX5o1C2Q==",
+      "requires": {
+        "@types/node": "^14.0.1",
+        "fast-deep-equal": "^3.1.1",
+        "fastify-plugin": "^2.0.0",
+        "forwarded": "^0.1.2",
+        "http-errors": "^1.7.3",
+        "type-is": "^1.6.18",
+        "vary": "^1.1.2"
       }
     },
     "fastify-warning": {
@@ -2995,6 +3019,18 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
+    },
+    "http-errors": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+      "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -3923,6 +3959,11 @@
         "supports-hyperlinks": "^2.1.0"
       }
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
     "memory-streams": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
@@ -4080,14 +4121,12 @@
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-      "dev": true
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
       "version": "2.1.27",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-      "dev": true,
       "requires": {
         "mime-db": "1.44.0"
       }
@@ -5421,6 +5460,11 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.6.tgz",
       "integrity": "sha512-mNCnTUF0OYPwYzSHbdRdCfNNHqrne+HS5tS5xNb6yJbdP9wInV0q5xPLE0EyfV/Q3tImo3y/OXpD8Jn0Jtnjrg=="
     },
+    "setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5672,6 +5716,11 @@
           "dev": true
         }
       }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stream-shift": {
       "version": "1.0.1",
@@ -7178,6 +7227,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -7268,6 +7322,15 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -7506,6 +7569,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "test"
   },
   "dependencies": {
+    "aws-sdk": "^2.786.0",
     "fastify": "^3.0.0",
     "fastify-auth": "^1.0.1",
     "fastify-autoload": "^3.3.0",
@@ -19,6 +20,7 @@
     "eslint-config-godaddy": "^4.0.1",
     "fastify-cli": "^2.3.0",
     "nodemon": "^2.0.4",
+    "prettier": "^2.1.2",
     "standard-version": "^9.0.0",
     "tap": "^14.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.786.0",
+    "dotenv": "^8.2.0",
     "fastify": "^3.0.0",
     "fastify-auth": "^1.0.1",
     "fastify-autoload": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "fastify-auth": "^1.0.1",
     "fastify-autoload": "^3.3.0",
     "fastify-plugin": "^2.3.0",
+    "fastify-sensible": "^3.0.1",
     "pino": "^6.7.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "lint": "npm run prettier && npm run eslint",
     "eslint": "eslint-godaddy --max-warnings 0 --ignore-pattern /coverage/ ./",
-    "prettier": "prettier --write 'lib/*.js'",
+    "prettier": "prettier --write lib",
     "release": "standard-version -t ''",
     "test": "tap test/**/*.test.js",
     "start": "node lib/app.js",


### PR DESCRIPTION
Adding object routes and models.
Follow other PRs related: test setup, controller logic add on etc

It only implements `GET /objects/:name` route. Other routes mockup only.
Will add implement other routes later with a separate PR.