### PR TITLE
refactor(cdn): remove ACL parameter from S3 uploads, rely on bucket policy instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+- Remove ACL parameter from S3 uploads, rely on bucket policy for public access.
+
 ## [7.4.2](https://github.com/godaddy/warehouse.ai/compare/7.4.0...7.4.2) (2025-10-29)
 
 ### Bug Fixes

--- a/lib/plugins/cdn.js
+++ b/lib/plugins/cdn.js
@@ -22,8 +22,6 @@ const finger = require('fingerprinting');
  * @property {WrhsAssetFile[]} files
  */
 
-const DEFAULT_ACL = 'public-read';
-
 module.exports = fp(
   /**
    * Initialize CDN plugin
@@ -139,7 +137,6 @@ module.exports = fp(
             ContentType: mime.lookup(filepath),
             Bucket: cdnS3Bucket,
             Key: filepath,
-            ACL: DEFAULT_ACL,
             Expires: expiration
           })
           .promise();


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

This change removes the object-level ACL parameter from S3 `putObject` calls, eliminating the need for the `s3:PutObjectAcl` IAM permission.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
### Motivation

Object-level ACLs are being phased out in favor of bucket policies as an AWS best practice. By removing the `ACL: 'public-read'` parameter, we can tighten IAM permissions and manage public access centrally through bucket policy instead.

## Changelog

- Removed `ACL` parameter from `uploadFileToStorage` function
- Removed unused `DEFAULT_ACL` constant
- Public read access is now controlled via bucket policy rather than per-object ACLs

## Test Plan

<!--
Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
