### PR TITLE
feat(aws)!: migrate to AWS SDK v3 and replace LocalStack with Floci

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - "main"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,12 +16,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     services:
-      localstack:
-        image: localstack/localstack:1.4.0
+      floci:
+        image: floci/floci:latest
         ports:
           - 4566:4566
-        env:
-          SERVICES: dynamodb,s3
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/bin/dynamo-tools.js
+++ b/bin/dynamo-tools.js
@@ -40,7 +40,8 @@ class DynamoTools {
       status = ret.Table.TableStatus;
       console.log(`Current status for ${region}/${tableName} is ${status}`);
     } catch (error) {
-      console.log(`describeTable ${region}/${tableName} - ${error.message}`);
+      const isExpected = error instanceof RangeError || error.name === 'ResourceNotFoundException';
+      if (!isExpected) console.log(`describeTable ${region}/${tableName} - ${error.message}`);
     }
     return status;
   }

--- a/bin/dynamo-tools.js
+++ b/bin/dynamo-tools.js
@@ -2,12 +2,13 @@
 
 /* eslint-disable no-console */
 
+const { DescribeTableCommand, CreateTableCommand } = require('@aws-sdk/client-dynamodb');
 const { tables, tableNames } = require('./dynamo-tables');
 
 /**
- * @typedef {import('aws-sdk').DynamoDB} AwsDynamoDB
+ * @typedef {import('@aws-sdk/client-dynamodb').DynamoDBClient} AwsDynamoDB
  * @typedef {Object<string, AwsDynamoDB>} DynamoClients
- * @typedef {AwsDynamoDB.CreateTableInput} DynamoCreateTableParams
+ * @typedef {import('@aws-sdk/client-dynamodb').CreateTableInput} DynamoCreateTableParams
  */
 
 /* Class for helping creating DynamoDB tables */
@@ -35,9 +36,7 @@ class DynamoTools {
     const client = this._clients[region];
     let status;
     try {
-      const ret = await client
-        .describeTable({ TableName: tableName })
-        .promise();
+      const ret = await client.send(new DescribeTableCommand({ TableName: tableName }));
       status = ret.Table.TableStatus;
       console.log(`Current status for ${region}/${tableName} is ${status}`);
     } catch (error) {
@@ -77,7 +76,7 @@ class DynamoTools {
         TableName: tableName,
         ...createTableParameters
       };
-      await client.createTable(params).promise();
+      await client.send(new CreateTableCommand(params));
     } catch (error) {
       console.error(`createTable ${region}/${tableName} - ${error.message}`);
     }

--- a/bin/init-localstack.js
+++ b/bin/init-localstack.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-const { DynamoDB, S3 } = require('aws-sdk');
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { S3Client } = require('@aws-sdk/client-s3');
 const DynamoTools = require('./dynamo-tools');
 const S3Tools = require('./s3-tools');
 
@@ -15,7 +16,7 @@ const credentials = {
 const endpoint = process.env.LOCALSTACK_URL || 'http://localhost:4566';
 
 const dynamoClients = dynamoRegions.reduce((acc, region) => {
-  acc[region] = new DynamoDB({
+  acc[region] = new DynamoDBClient({
     endpoint,
     credentials,
     region
@@ -30,10 +31,10 @@ const dynamoTools = new DynamoTools({
 
 const s3Region = 'us-west-2';
 const s3Tools = new S3Tools({
-  client: new S3({
+  client: new S3Client({
     endpoint,
     credentials,
-    s3ForcePathStyle: true,
+    forcePathStyle: true,
     region: s3Region
   }),
   region: s3Region

--- a/bin/s3-tools.js
+++ b/bin/s3-tools.js
@@ -39,7 +39,8 @@ class S3Tools {
       );
     } catch (error) {
       status = 'NOT_CREATED';
-      console.log(`headBucket - ${error.message}`);
+      const isExpected = error instanceof RangeError || error.$metadata?.httpStatusCode === 404 || error.name === 'NotFound';
+      if (!isExpected) console.log(`headBucket - ${error.message}`);
     }
     return status;
   }

--- a/bin/s3-tools.js
+++ b/bin/s3-tools.js
@@ -38,9 +38,14 @@ class S3Tools {
         `Current status for ${this._region}/${bucketName} is ${status}`
       );
     } catch (error) {
-      status = 'NOT_CREATED';
-      const isExpected = error instanceof RangeError || error.$metadata?.httpStatusCode === 404 || error.name === 'NotFound';
-      if (!isExpected) console.log(`headBucket - ${error.message}`);
+      if (error instanceof RangeError) {
+        // SDK v3 can't parse LocalStack's Date response header on a 200, but the bucket exists
+        status = 'CREATED';
+      } else {
+        status = 'NOT_CREATED';
+        const isExpected = error.$metadata?.httpStatusCode === 404 || error.name === 'NotFound';
+        if (!isExpected) console.log(`headBucket - ${error.message}`);
+      }
     }
     return status;
   }

--- a/bin/s3-tools.js
+++ b/bin/s3-tools.js
@@ -2,10 +2,11 @@
 
 /* eslint-disable no-console */
 
+const { HeadBucketCommand, CreateBucketCommand } = require('@aws-sdk/client-s3');
 const { bucketNames } = require('./s3-buckets');
 
 /**
- * @typedef {import('aws-sdk').S3} AwsS3
+ * @typedef {import('@aws-sdk/client-s3').S3Client} AwsS3
  */
 
 /* Class for helping creating S3 buckets */
@@ -31,7 +32,7 @@ class S3Tools {
   async getBucketStatus(bucketName) {
     let status;
     try {
-      await this._client.headBucket({ Bucket: bucketName }).promise();
+      await this._client.send(new HeadBucketCommand({ Bucket: bucketName }));
       status = 'CREATED';
       console.log(
         `Current status for ${this._region}/${bucketName} is ${status}`
@@ -71,7 +72,7 @@ class S3Tools {
           LocationConstraint: this._region
         }
       };
-      await this._client.createBucket(createBucketParameters).promise();
+      await this._client.send(new CreateBucketCommand(createBucketParameters));
     } catch (error) {
       console.error(
         `createBucket ${this._region}/${bucketName} - ${error.message}`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,8 @@
 version: "3.8"
 
 services:
-  localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
-    image: localstack/localstack:1.4.0
+  floci:
+    container_name: floci_main
+    image: floci/floci:latest
     ports:
-      - "4566:4566"            # LocalStack Gateway
-      - "9999:8080"
-    environment:
-      - DEBUG=${DEBUG-}
-      - SERVICES=dynamodb,s3
-      - DOCKER_HOST=unix:///var/run/docker.sock
-    volumes:
-      - "${TMPDIR:-/tmp/localstack}:/var/lib/localstack"
-      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "4566:4566"

--- a/lib/config.js
+++ b/lib/config.js
@@ -39,7 +39,7 @@ module.exports = fp(
       const region = process.env.AWS_REGION || 'us-west-2';
       const credentials = { accessKeyId: 'foo', secretAccessKey: 'bar' };
       config.dynamo = { endpoint, region, credentials };
-      config.s3 = { endpoint, region, credentials, s3ForcePathStyle: true };
+      config.s3 = { endpoint, region, credentials, forcePathStyle: true };
     }
 
     fastify.decorate('config', config);

--- a/lib/plugins/aws.js
+++ b/lib/plugins/aws.js
@@ -19,25 +19,6 @@ module.exports = fp(
     fastify.decorate('dynamo', dynamo);
 
     const s3 = new S3Client(fastify.config.s3);
-
-    // LocalStack 1.4.0 returns unparseable Date headers on S3 responses. SDK v3
-    // reads that header to correct its clock offset; if it's invalid the offset
-    // becomes NaN, which then causes the next request's SigV4 signing to throw
-    // "Invalid time value". Strip any invalid Date header before the SDK sees it.
-    if (fastify.config.s3.endpoint) {
-      s3.middlewareStack.add(
-        (next) => async (args) => {
-          const result = await next(args); // eslint-disable-line callback-return
-          const date = result.response?.headers?.date;
-          if (date && isNaN(new Date(date).getTime())) {
-            delete result.response.headers.date;
-          }
-          return result;
-        },
-        { step: 'deserialize', priority: 'low', name: 'fixLocalstackDateHeader' }
-      );
-    }
-
     fastify.decorate('s3', s3);
   },
   {

--- a/lib/plugins/aws.js
+++ b/lib/plugins/aws.js
@@ -19,6 +19,25 @@ module.exports = fp(
     fastify.decorate('dynamo', dynamo);
 
     const s3 = new S3Client(fastify.config.s3);
+
+    // LocalStack 1.4.0 returns unparseable Date headers on S3 responses. SDK v3
+    // reads that header to correct its clock offset; if it's invalid the offset
+    // becomes NaN, which then causes the next request's SigV4 signing to throw
+    // "Invalid time value". Strip any invalid Date header before the SDK sees it.
+    if (fastify.config.s3.endpoint) {
+      s3.middlewareStack.add(
+        (next) => async (args) => {
+          const result = await next(args); // eslint-disable-line callback-return
+          const date = result.response?.headers?.date;
+          if (date && isNaN(new Date(date).getTime())) {
+            delete result.response.headers.date;
+          }
+          return result;
+        },
+        { step: 'deserialize', priority: 'low', name: 'fixLocalstackDateHeader' }
+      );
+    }
+
     fastify.decorate('s3', s3);
   },
   {

--- a/lib/plugins/aws.js
+++ b/lib/plugins/aws.js
@@ -1,5 +1,7 @@
 const fp = require('fastify-plugin');
-const { DynamoDB, S3 } = require('aws-sdk');
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient } = require('@aws-sdk/lib-dynamodb');
+const { S3Client } = require('@aws-sdk/client-s3');
 
 /**
  * @typedef {import('fastify').FastifyInstance} FastifyInstance
@@ -13,10 +15,10 @@ module.exports = fp(
    * @returns {Promise<void>} Promise representing plugin initialization result
    */
   async function (fastify) {
-    const dynamo = new DynamoDB.DocumentClient(fastify.config.dynamo);
+    const dynamo = DynamoDBDocumentClient.from(new DynamoDBClient(fastify.config.dynamo));
     fastify.decorate('dynamo', dynamo);
 
-    const s3 = new S3(fastify.config.s3);
+    const s3 = new S3Client(fastify.config.s3);
     fastify.decorate('s3', s3);
   },
   {

--- a/lib/plugins/cdn.js
+++ b/lib/plugins/cdn.js
@@ -2,9 +2,10 @@ const fp = require('fastify-plugin');
 const mime = require('mime-types');
 const tar = require('tar');
 const finger = require('fingerprinting');
+const { PutObjectCommand } = require('@aws-sdk/client-s3');
 
 /**
- * @typedef {import('aws-sdk').S3.PutObjectOutput} AWSPutObjectResponse
+ * @typedef {import('@aws-sdk/client-s3').PutObjectCommandOutput} AWSPutObjectResponse
  * @typedef {import('stream').Readable} ReadableStream
  * @typedef {import('buffer').Buffer } Buffer
  * @typedef {import('../warehouse').WarehouseApp} WarehouseApp
@@ -144,9 +145,7 @@ module.exports = fp(
           objectToPut.ACL = acl;
         }
 
-        return storage
-          .putObject(objectToPut)
-          .promise();
+        return storage.send(new PutObjectCommand(objectToPut));
       }
     );
 

--- a/lib/plugins/env.js
+++ b/lib/plugins/env.js
@@ -1,4 +1,9 @@
 const fp = require('fastify-plugin');
+const {
+  GetCommand,
+  QueryCommand,
+  TransactWriteCommand
+} = require('@aws-sdk/lib-dynamodb');
 
 const ENVS_TABLE = 'warehouse-envs';
 const ENV_ALIASES_TABLE = 'warehouse-env-aliases';
@@ -49,15 +54,15 @@ module.exports = fp(
        * @returns {Promise<Object>} The object
        */
       async function getEnvs({ name: keyname }) {
-        const { Items: objEnvs } = await dynamo
-          .query({
+        const { Items: objEnvs } = await dynamo.send(
+          new QueryCommand({
             KeyConditionExpression: 'keyname = :name',
             ExpressionAttributeValues: {
               ':name': keyname
             },
             TableName: ENVS_TABLE
           })
-          .promise();
+        );
         return objEnvs.map((obj) => cleanEnvRecord(obj));
       }
     );
@@ -77,7 +82,7 @@ module.exports = fp(
           Key: { keyname, env },
           TableName: ENVS_TABLE
         };
-        const { Item: item } = await dynamo.get(params).promise();
+        const { Item: item } = await dynamo.send(new GetCommand(params));
         if (!item) return null;
         return cleanEnvRecord(item);
       }
@@ -98,7 +103,7 @@ module.exports = fp(
           Key: { keyname, alias },
           TableName: ENV_ALIASES_TABLE
         };
-        const { Item: item } = await dynamo.get(params).promise();
+        const { Item: item } = await dynamo.send(new GetCommand(params));
         if (!item) return null;
         return cleanEnvAliasRecord(item);
       }
@@ -138,7 +143,7 @@ module.exports = fp(
           }
         ];
 
-        return dynamo.transactWrite({ TransactItems: transactItems }).promise();
+        return dynamo.send(new TransactWriteCommand({ TransactItems: transactItems }));
       }
     );
 
@@ -181,7 +186,7 @@ module.exports = fp(
           }
         ];
 
-        return dynamo.transactWrite({ TransactItems: transactItems }).promise();
+        return dynamo.send(new TransactWriteCommand({ TransactItems: transactItems }));
       }
     );
   },

--- a/lib/plugins/hook.js
+++ b/lib/plugins/hook.js
@@ -1,5 +1,11 @@
 const fp = require('fastify-plugin');
 const { v4: uuidv4 } = require('uuid');
+const {
+  GetCommand,
+  QueryCommand,
+  PutCommand,
+  DeleteCommand
+} = require('@aws-sdk/lib-dynamodb');
 
 const HOOKS_TABLE = 'warehouse-hooks';
 
@@ -38,15 +44,15 @@ module.exports = fp(
        * @returns {Promise<Object>} The object
        */
       async function getHooks({ name: keyname }) {
-        const { Items: hooks } = await dynamo
-          .query({
+        const { Items: hooks } = await dynamo.send(
+          new QueryCommand({
             KeyConditionExpression: 'keyname = :name',
             ExpressionAttributeValues: {
               ':name': keyname
             },
             TableName: HOOKS_TABLE
           })
-          .promise();
+        );
         return hooks.map((hook) => cleanHookRecord(hook));
       }
     );
@@ -66,7 +72,7 @@ module.exports = fp(
           Key: { keyname, id },
           TableName: HOOKS_TABLE
         };
-        const { Item: item } = await dynamo.get(params).promise();
+        const { Item: item } = await dynamo.send(new GetCommand(params));
         if (!item) return null;
         return cleanHookRecord(item);
       }
@@ -85,8 +91,8 @@ module.exports = fp(
       async function createHook({ name: keyname, url }) {
         const id = uuidv4();
 
-        await dynamo
-          .put({
+        await dynamo.send(
+          new PutCommand({
             Item: {
               keyname,
               id,
@@ -94,7 +100,7 @@ module.exports = fp(
             },
             TableName: HOOKS_TABLE
           })
-          .promise();
+        );
 
         return id;
       }
@@ -115,7 +121,7 @@ module.exports = fp(
           Key: { keyname, id },
           TableName: HOOKS_TABLE
         };
-        return dynamo.delete(params).promise();
+        return dynamo.send(new DeleteCommand(params));
       }
     );
   },

--- a/lib/plugins/object.js
+++ b/lib/plugins/object.js
@@ -1,5 +1,14 @@
 const { compareVersions } = require('compare-versions/lib/umd');
 const fp = require('fastify-plugin');
+const {
+  GetCommand,
+  QueryCommand,
+  PutCommand,
+  UpdateCommand,
+  DeleteCommand,
+  BatchGetCommand,
+  TransactWriteCommand
+} = require('@aws-sdk/lib-dynamodb');
 
 const OBJECTS_TABLE = 'warehouse-objects';
 const OBJECT_VARIANTS_TABLE = 'warehouse-object-variants';
@@ -48,7 +57,7 @@ module.exports = fp(
           Key: { keyname, env },
           TableName: OBJECTS_TABLE
         };
-        const { Item: item } = await dynamo.get(params).promise();
+        const { Item: item } = await dynamo.send(new GetCommand(params));
         return item;
       }
     );
@@ -108,7 +117,7 @@ module.exports = fp(
           }
         ];
 
-        return dynamo.transactWrite({ TransactItems: transactItems }).promise();
+        return dynamo.send(new TransactWriteCommand({ TransactItems: transactItems }));
       }
     );
 
@@ -124,15 +133,15 @@ module.exports = fp(
        * @returns {Promise<any>} The operation result
        */
       async function getHistoryRecord({ name, env, timestamp }) {
-        const { Item: item } = await dynamo
-          .get({
+        const { Item: item } = await dynamo.send(
+          new GetCommand({
             Key: {
               id: `${name}_${env}`,
               timestamp
             },
             TableName: OBJECT_HISTORY_TABLE
           })
-          .promise();
+        );
 
         return item;
       }
@@ -149,15 +158,15 @@ module.exports = fp(
        * @returns {Promise<any>} The operation result
        */
       async function getHistoryRecords({ name, env }) {
-        const { Items: items } = await dynamo
-          .query({
+        const { Items: items } = await dynamo.send(
+          new QueryCommand({
             KeyConditionExpression: 'id = :id',
             ExpressionAttributeValues: {
               ':id': `${name}_${env}`
             },
             TableName: OBJECT_HISTORY_TABLE
           })
-          .promise();
+        );
 
         return items;
       }
@@ -174,8 +183,8 @@ module.exports = fp(
        * @returns {Promise<any>} The operation result
        */
       async function deleteObject({ name, env }) {
-        const { Items: objVariants } = await dynamo
-          .query({
+        const { Items: objVariants } = await dynamo.send(
+          new QueryCommand({
             IndexName: 'keyname-env-index',
             KeyConditionExpression: 'keyname = :name AND env = :env',
             ExpressionAttributeValues: {
@@ -184,7 +193,7 @@ module.exports = fp(
             },
             TableName: OBJECT_VARIANTS_TABLE
           })
-          .promise();
+        );
 
         const params = objVariants.reduce(
           (acc, obj) => {
@@ -210,7 +219,7 @@ module.exports = fp(
           }
         );
 
-        return dynamo.transactWrite(params).promise();
+        return dynamo.send(new TransactWriteCommand(params));
       }
     );
 
@@ -236,7 +245,7 @@ module.exports = fp(
           Key: { id, variant },
           TableName: OBJECT_VARIANTS_TABLE
         };
-        const { Item: item } = await dynamo.get(params).promise();
+        const { Item: item } = await dynamo.send(new GetCommand(params));
         return item ? cleanVariantRecord(item) : null;
       }
     );
@@ -264,7 +273,7 @@ module.exports = fp(
           Key: { id, variant },
           TableName: OBJECT_VARIANTS_TABLE
         };
-        return dynamo.delete(params).promise();
+        return dynamo.send(new DeleteCommand(params));
       }
     );
 
@@ -313,8 +322,8 @@ module.exports = fp(
           newHeadVersion !== headVersion ||
           newLatestVersion !== latestVersion
         ) {
-          await dynamo
-            .update({
+          await dynamo.send(
+            new UpdateCommand({
               TableName: OBJECTS_TABLE,
               Key: { keyname: name, env },
               UpdateExpression:
@@ -328,7 +337,7 @@ module.exports = fp(
                 ':latestVersion': latestVersion
               }
             })
-            .promise();
+          );
 
           return true;
         }
@@ -374,7 +383,7 @@ module.exports = fp(
           }
         );
 
-        return dynamo.transactWrite(params).promise();
+        return dynamo.send(new TransactWriteCommand(params));
       }
     );
 
@@ -400,7 +409,7 @@ module.exports = fp(
             }
           }
         };
-        const { Responses: results } = await dynamo.batchGet(params).promise();
+        const { Responses: results } = await dynamo.send(new BatchGetCommand(params));
         return results[OBJECT_VARIANTS_TABLE].map((item) =>
           cleanVariantRecord(item)
         );
@@ -426,7 +435,7 @@ module.exports = fp(
           },
           TableName: OBJECT_VARIANTS_TABLE
         };
-        const { Items: items } = await dynamo.query(params).promise();
+        const { Items: items } = await dynamo.send(new QueryCommand(params));
         return items.map((item) => cleanVariantRecord(item));
       }
     );
@@ -451,7 +460,7 @@ module.exports = fp(
           },
           TableName: OBJECT_VARIANTS_TABLE
         };
-        const { Items: items } = await dynamo.query(params).promise();
+        const { Items: items } = await dynamo.send(new QueryCommand(params));
         const results = items.map((item) => item.version);
         return Array.from(new Set(results));
       }
@@ -479,7 +488,7 @@ module.exports = fp(
           }
         };
 
-        const { Items: items } = await dynamo.query(params).promise();
+        const { Items: items } = await dynamo.send(new QueryCommand(params));
 
         if (!items || items.length === 0) {
           return false;
@@ -592,7 +601,7 @@ module.exports = fp(
           });
         }
 
-        return dynamo.transactWrite({ TransactItems: transactItems }).promise();
+        return dynamo.send(new TransactWriteCommand({ TransactItems: transactItems }));
       }
     );
 
@@ -621,7 +630,7 @@ module.exports = fp(
           Item: { id, timestamp, headVersion, prevTimestamp },
           TableName: OBJECT_HISTORY_TABLE
         };
-        return dynamo.put(params).promise();
+        return dynamo.send(new PutCommand(params));
       }
     );
   },

--- a/lib/routes/objects.js
+++ b/lib/routes/objects.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-statements */
 
 const fetch = require('node-fetch');
+const { compareVersions } = require('compare-versions/lib/umd');
 
 /**
  * @typedef {import('fastify').FastifyRequest} FastifyRequest
@@ -427,6 +428,7 @@ module.exports =
             allVersions.push({ version, environments });
           }
 
+          allVersions.sort((a, b) => compareVersions(b.version, a.version));
           res.send(allVersions);
         }
     });

--- a/lib/warehouse.js
+++ b/lib/warehouse.js
@@ -8,8 +8,8 @@ const path = require('path');
 const config = require('./config');
 
 /**
- * @typedef {import('aws-sdk').DynamoDB.DocumentClient} DocumentClient
- * @typedef {import('aws-sdk').S3} S3
+ * @typedef {import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient} DocumentClient
+ * @typedef {import('@aws-sdk/client-s3').S3Client} S3Client
  * @typedef {import('fastify').FastifyInstance} FastifyInstance
  * @typedef {import('fastify').FastifyPluginOptions} FastifyPluginOptions
  * @typedef {import('pino').Logger} PinoLogger
@@ -42,7 +42,7 @@ const config = require('./config');
 /**
  * @typedef {Object} WarehouseExtension
  * @property {DocumentClient} [dynamo]
- * @property {S3} [s3]
+ * @property {S3Client} [s3]
  * @property {WarehouseLogger} log
  *
  * @typedef {FastifyInstance & WarehouseExtension} WarehouseApp

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "warehouse.ai",
-  "version": "7.6.0",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "warehouse.ai",
-      "version": "7.6.0",
+      "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
         "compare-versions": "^5.0.3",
@@ -25,7 +25,9 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "aws-sdk": "^2.1586.0",
+        "@aws-sdk/client-dynamodb": "^3.1116.0",
+        "@aws-sdk/client-s3": "^3.1116.0",
+        "@aws-sdk/lib-dynamodb": "^3.1116.0",
         "commit-and-tag-version": "^13.0.0",
         "eslint": "^8.57.0",
         "eslint-config-godaddy": "^7.1.0",
@@ -38,7 +40,9 @@
         "tap": "^21.7.5"
       },
       "peerDependencies": {
-        "aws-sdk": ">= 2.800.0 < 3",
+        "@aws-sdk/client-dynamodb": "^3",
+        "@aws-sdk/client-s3": "^3",
+        "@aws-sdk/lib-dynamodb": "^3",
         "fastify": ">= 3 < 4",
         "fastify-plugin": ">= 3 < 4"
       }
@@ -81,6 +85,437 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.29.tgz",
+      "integrity": "sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1116.0.tgz",
+      "integrity": "sha512-dsz5jnx6hkU3xz2B93P1QAknD+gfPGTl8vld9g/6WXj2bZItDhAJXZNtda/02iX5+tA3cffkxBfWRYncwgw26g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-node": "^3.972.81",
+        "@aws-sdk/dynamodb-codec": "^3.973.44",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.30",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1116.0.tgz",
+      "integrity": "sha512-UKRl9qSVW0rZpvSOauQNpYAy8+ONBAVYnpfKVtCyOF+FZVT1tl6MunYuHvuarCrroD2/YJs+tHTALYNgAlec3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.29",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-node": "^3.972.81",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.75",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.81",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.81.tgz",
+      "integrity": "sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.44.tgz",
+      "integrity": "sha512-eo27HNeBqMAfy9JBQug6ErU6DeG8OmOH6ou8+KmX3/fWdTmWUsHsfisz2tEQOG+GJ57bBC7kC6AjKAjpcxU4QA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.11.tgz",
+      "integrity": "sha512-8q1ICxcDjHId3bBryuu/j+1L9y5/3uQnwzLDt5j2ElcjZSoWmFtymdJy7OjLrluSMe0Z4mq5bcH4fxBXvlEHfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1116.0.tgz",
+      "integrity": "sha512-MZit1i361/0GX4eNxoXfBKylnZB/ZLD9rslwIPxqA6FMrOFhNtwP3Jq7qaj8KDrzxcxmcuyqZmRlI4hY6UWUog==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/util-dynamodb": "^3.996.9",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1116.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.30.tgz",
+      "integrity": "sha512-0hmD7/NG2NoVOVHvUb6rtY5POQYr+/9gdHvrYhIBA1zmCqKOBd5Gz3dL+iZ15FHOJbs/5kLplGoePc8PHTlzYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.11",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.75.tgz",
+      "integrity": "sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.9.tgz",
+      "integrity": "sha512-16x2tRvl7OYpZ0W/DdFJieFriD13+RvuRBDbe5sj/tCEfK86HSGd7I2s5j0ivz8p6KWGkS+5wKRO9OliJkjUOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1111.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@base2/pretty-print-object": {
@@ -880,6 +1315,93 @@
       },
       "funding": {
         "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
+      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@tapjs/after": {
@@ -2193,22 +2715,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/avvio": {
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/avvio/-/avvio-7.2.5.tgz",
@@ -2220,41 +2726,6 @@
         "debug": "^4.0.0",
         "fastq": "^1.6.1",
         "queue-microtask": "^1.1.2"
-      }
-    },
-    "node_modules/aws-sdk": {
-      "version": "2.1693.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1693.0.tgz",
-      "integrity": "sha512-cJmb8xEnVLT+R6fBS5sn/EFJiX7tUnDaPtOPZ1vFbOJtd0fnZn/Ky2XGgsvvoeliWeH7mL3TWSX5zXXGSQV6gQ==",
-      "deprecated": "The AWS SDK for JavaScript (v2) has reached end-of-support, and no longer receives updates. Please migrate your code to use AWS SDK for JavaScript (v3). More info https://a.co/cUPnyil",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.16.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "util": "^0.12.4",
-        "uuid": "8.0.0",
-        "xml2js": "0.6.2"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/aws-sdk/node_modules/uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/balanced-match": {
@@ -2409,6 +2880,13 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
@@ -2438,18 +2916,6 @@
       "integrity": "sha512-wbMxoJJM1p3+6G7xEFXYNCJ30h2qkwmVxebkbwIl4OcnWtno5R3UT9VuYLfStlVNAQCmRjkGwjPFdfaPd4iNXw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
-      }
     },
     "node_modules/buffers": {
       "version": "0.1.1",
@@ -2722,56 +3188,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -3478,24 +3894,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -3657,21 +4055,6 @@
         "x256": ">=0.0.1"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3736,45 +4119,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/es-toolkit": {
       "version": "1.50.0",
@@ -4159,16 +4509,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.x"
       }
     },
     "node_modules/events-to-array": {
@@ -4744,22 +5084,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/foreground-child": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-4.0.3.tgz",
@@ -4849,32 +5173,12 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/function-loop": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-4.0.0.tgz",
       "integrity": "sha512-f34iQBedYF3XcI93uewZZOnyscDragxgTK/eTvVB74k3fCD0ZorOi5BV9GS4M8rz/JoNi0Kl3qX5Y9MH3S/CLQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/generator-function": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
-      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/generify": {
       "version": "4.2.0",
@@ -4923,45 +5227,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/gl-matrix": {
@@ -5021,19 +5286,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -5079,61 +5331,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/help-me": {
@@ -5229,13 +5426,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -5565,23 +5755,6 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -5593,19 +5766,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-docker": {
@@ -5642,26 +5802,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
-      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.4",
-        "generator-function": "^2.0.0",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -5723,41 +5863,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-unsafe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
@@ -5769,13 +5874,6 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isbinaryfile": {
@@ -5854,16 +5952,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jmespath": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/joycon": {
@@ -6243,16 +6331,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -6504,6 +6582,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
       }
     },
     "node_modules/ms": {
@@ -6867,6 +6955,13 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -7565,16 +7660,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7736,16 +7821,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.x"
       }
     },
     "node_modules/queue-microtask": {
@@ -8127,24 +8202,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/safe-regex2": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
@@ -8260,24 +8317,6 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -9394,38 +9433,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9590,28 +9597,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.22",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
-      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.9",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which/node_modules/isexe": {
@@ -9848,20 +9833,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warehouse.ai",
-  "version": "8.0.0",
+  "version": "7.6.0",
   "description": "Scalable Object Ledger and CDN",
   "main": "lib/app.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warehouse.ai",
-  "version": "7.6.0",
+  "version": "8.0.0",
   "description": "Scalable Object Ledger and CDN",
   "main": "lib/app.js",
   "directories": {
@@ -24,12 +24,17 @@
     "uuid": "^9.0.1"
   },
   "peerDependencies": {
-    "aws-sdk": ">= 2.800.0 < 3",
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/client-s3": "^3",
+    "@aws-sdk/lib-dynamodb": "^3",
     "fastify": ">= 3 < 4",
     "fastify-plugin": ">= 3 < 4"
   },
   "devDependencies": {
-    "aws-sdk": "^2.1586.0",
+    "@aws-sdk/client-dynamodb": "^3.1116.0",
+    "@aws-sdk/client-s3": "^3.1116.0",
+    "@aws-sdk/lib-dynamodb": "^3.1116.0",
+    "commit-and-tag-version": "^13.0.0",
     "eslint": "^8.57.0",
     "eslint-config-godaddy": "^7.1.0",
     "fastify": "^3.29.5",
@@ -38,7 +43,6 @@
     "nock": "^13.5.4",
     "nodemon": "^2.0.22",
     "pino-pretty": "^10.0.0",
-    "commit-and-tag-version": "^13.0.0",
     "tap": "^21.7.5"
   },
   "scripts": {

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,5 +1,6 @@
 const createFastify = require('fastify');
 const fp = require('fastify-plugin');
+const { QueryCommand } = require('@aws-sdk/lib-dynamodb');
 const warehouse = require('../lib/warehouse');
 
 const OBJECT_HISTORY_TABLE = 'warehouse-object-history';
@@ -115,7 +116,7 @@ async function getHistoryRecords(f, { name, env }) {
     },
     TableName: OBJECT_HISTORY_TABLE
   };
-  const { Items: items } = await f.dynamo.query(params).promise();
+  const { Items: items } = await f.dynamo.send(new QueryCommand(params));
   return items;
 }
 

--- a/test/routes/cdn.test.js
+++ b/test/routes/cdn.test.js
@@ -3,6 +3,7 @@
 const { promises: fs } = require('fs');
 const path = require('path');
 const { test } = require('tap');
+const { ListObjectsV2Command } = require('@aws-sdk/client-s3');
 const { build } = require('../helper');
 
 test('CDN API', async (t) => {
@@ -52,9 +53,9 @@ test('CDN API', async (t) => {
       ]
     });
 
-    const { Contents: files } = await fastify.s3
-      .listObjectsV2({ Bucket: 'warehouse-cdn' })
-      .promise();
+    const { Contents: files } = await fastify.s3.send(
+      new ListObjectsV2Command({ Bucket: 'warehouse-cdn' })
+    );
     const filenames = files.map(({ Key }) => Key);
 
     const expectedFiles = [
@@ -122,9 +123,9 @@ test('CDN API', async (t) => {
       ]
     });
 
-    const { Contents: files } = await fastify.s3
-      .listObjectsV2({ Bucket: 'warehouse-cdn' })
-      .promise();
+    const { Contents: files } = await fastify.s3.send(
+      new ListObjectsV2Command({ Bucket: 'warehouse-cdn' })
+    );
     const filenames = files.map(({ Key }) => Key);
     const expectedFiles = [
       '318a308660ba069e74d756cdc854ca52/main.js',


### PR DESCRIPTION
## Summary

**AWS SDK v2 → v3**
- Replace `aws-sdk` with `@aws-sdk/client-dynamodb`, `@aws-sdk/lib-dynamodb`, `@aws-sdk/client-s3`
- Update all client constructors to v3 (`DynamoDBDocumentClient.from(new DynamoDBClient(...))`, `new S3Client(...)`)
- Replace all `.method(params).promise()` chains with `client.send(new XxxCommand(params))`
- Rename `s3ForcePathStyle` → `forcePathStyle` in config
- Update all JSDoc `@typedef` imports to reference v3 types

**LocalStack → Floci**
- Replace `localstack/localstack:1.4.0` with `floci/floci:latest` in `docker-compose.yml` and CI
- Floci is a drop-in replacement (same port, same credentials, same endpoint URL), actively maintained, MIT-licensed, ~24 ms startup vs ~3.3 s, ~90 MB image vs ~1 GB
- LocalStack Community was sunset in March 2026 and now requires auth tokens

**Bug fix (uncovered by Floci)**
- `GET /objects/:name/versions` now sorts results by semver descending; the previous implicit ordering relied on a LocalStack 1.4.0 bug that returned DynamoDB Query results in non-standard descending order

## Breaking changes for consumers

This is a **semver major** release. Apps using `warehouse.ai` as a library need to:

1. Install the new peer dependencies and remove `aws-sdk` v2:
   ```
   npm install @aws-sdk/client-dynamodb @aws-sdk/client-s3 @aws-sdk/lib-dynamodb
   npm uninstall aws-sdk
   ```
2. Update any direct calls to `fastify.dynamo` or `fastify.s3` from the v2 style:
   ```js
   // before
   await fastify.s3.putObject(params).promise()
   await fastify.dynamo.get(params).promise()
   // after
   await fastify.s3.send(new PutObjectCommand(params))
   await fastify.dynamo.send(new GetCommand(params))
   ```

## Test plan

- [x] Start Floci (`npm run localstack`) and run `npm run init-localstack`
- [x] Run full test suite (`npm test`) — 118/118 pass, ESLint clean
- [x] CDN upload, DynamoDB object/env/hook CRUD routes verified end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)